### PR TITLE
Mark Element.setAttribute's parameters as required

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2969,7 +2969,7 @@ interface Element extends Node, GlobalEventHandlers, ElementTraversal, NodeSelec
     removeAttributeNode(oldAttr: Attr): Attr;
     requestFullscreen(): void;
     requestPointerLock(): void;
-    setAttribute(name?: string, value?: string): void;
+    setAttribute(name: string, value: string): void;
     setAttributeNS(namespaceURI: string, qualifiedName: string, value: string): void;
     setAttributeNode(newAttr: Attr): Attr;
     setAttributeNodeNS(newAttr: Attr): Attr;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -277,5 +277,11 @@
         "interface": "HTMLTableRowElement",
         "name": "insertCell",
         "signatures": ["insertCell(index?: number): HTMLTableCellElement"]
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "setAttribute",
+        "signatures": ["setAttribute(name: string, value: string): void"]
     }
 ]


### PR DESCRIPTION
This fixes Microsoft/TypeScript#4407, which was reported as being an error on `HTMLElement`. The actual error was with `Element`.