### PR TITLE
ReadyState type is a string

### DIFF
--- a/JS.fsx
+++ b/JS.fsx
@@ -40,7 +40,7 @@ let DomTypeToPrimitiveJsType domType =
     | "long long" -> "Number"
     | "long" -> "Number"
     | "object" -> "Object"
-    | "ReadyState" -> "Number"
+    | "ReadyState" -> "String"
     | "short" -> "Number"
     | "signed long" -> "Number"
     | "signed long long" -> "Number"

--- a/TS.fsx
+++ b/TS.fsx
@@ -35,7 +35,7 @@ let rec DomTypeToTsType (objDomType: string) =
     | "long" | "long long" | "signed long" | "signed long long" | "unsigned long" | "unsigned long long" -> "number"
     | "object" -> "any"
     | "Promise" -> "Promise"
-    | "ReadyState" -> "number"
+    | "ReadyState" -> "string"
     | "sequence" -> "Array"
     | "short" | "signed short" | "unsigned short" -> "number"
     | "UnrestrictedDouble" -> "number"

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7638,7 +7638,7 @@ declare var MediaQueryList: {
 interface MediaSource extends EventTarget {
     activeSourceBuffers: SourceBufferList;
     duration: number;
-    readyState: number;
+    readyState: string;
     sourceBuffers: SourceBufferList;
     addSourceBuffer(type: string): SourceBuffer;
     endOfStream(error?: number): void;


### PR DESCRIPTION
`MediaSource.readyState` is a [`ReadyState` string enum](https://w3c.github.io/media-source/#idl-def-ReadyState), but TypeScript [reports it](https://github.com/Microsoft/TSJS-lib-generator/blob/e9be0cb8e95e2a4b998cc0a658675127aac35e17/baselines/dom.generated.d.ts#L7641) to be a `number`.