### PR TITLE
Override type of HTMLMediaElement.readyState

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5513,7 +5513,7 @@ interface HTMLMediaElement extends HTMLElement {
       * Gets or sets the current playback position, in seconds.
       */
     preload: string;
-    readyState: any;
+    readyState: number;
     /**
       * Returns a TimeRanges object that represents the ranges of the current media resource that can be seeked.
       */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -283,5 +283,11 @@
         "interface": "Element",
         "name": "setAttribute",
         "signatures": ["setAttribute(name: string, value: string): void"]
+    },
+    {
+        "kind": "property",
+        "interface": "HTMLMediaElement",
+        "name": "readyState",
+        "type": "number"
     }
 ]


### PR DESCRIPTION
[The WebIDL file](https://github.com/Microsoft/TSJS-lib-generator/blob/472b4b1921d2b58ed8ae6505119d336d706ad972/inputfiles/browser.webidl.xml#L3747), reports `HTMLMediaElement.readyState` to be of type `any`. According to [the specification](https://html.spec.whatwg.org/multipage/embedded-content.html#htmlmediaelement) however, it should be of type `unsigned short` (which translates to `number` in TypeScript).

This PR adds an override for `HTMLMediaElement.readyState`.