### PR TITLE
Update AudioNode and DecodeErrorCallback to webaudio spec

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -378,6 +378,8 @@ interface AudioNode extends EventTarget {
     numberOfOutputs: number;
     connect(destination: AudioNode, output?: number, input?: number): void;
     disconnect(output?: number): void;
+    disconnect(destination: AudioNode, output?: number, input?: number): void;
+    disconnect(destination: AudioParam, output?: number): void;
 }
 
 declare var AudioNode: {
@@ -12689,7 +12691,7 @@ interface DecodeSuccessCallback {
     (decodedData: AudioBuffer): void;
 }
 interface DecodeErrorCallback {
-    (): void;
+    (error: DOMException): void;
 }
 interface FunctionStringCallback {
     (data: string): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -960,7 +960,7 @@ interface DecodeSuccessCallback {
     (decodedData: AudioBuffer): void;
 }
 interface DecodeErrorCallback {
-    (): void;
+    (error: DOMException): void;
 }
 interface FunctionStringCallback {
     (data: string): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -349,5 +349,20 @@
         "interface": "Window",
         "name": "open",
         "signatures": ["open(url?: string, target?: string, features?: string, replace?: boolean): Window"]
+    },
+    {
+        "kind": "method",
+        "interface": "AudioNode",
+        "name": "disconnect",
+        "signatures": [
+             "disconnect(output?: number): void",
+             "disconnect(destination: AudioNode, output?: number, input?: number): void",
+             "disconnect(destination: AudioParam, output?: number): void"
+        ]
+    },
+    {
+        "kind": "callback",
+        "name": "DecodeErrorCallback",
+        "signatures": ["(error: DOMException): void"]
     }
 ]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/6534

[Spec](https://webaudio.github.io/web-audio-api/#BaseAudioContext) here.

The `disconnect` signature is simplified by optional parameter.