### PR TITLE
Choose to not expose some property for "window" interface

### DIFF
--- a/TS.fsx
+++ b/TS.fsx
@@ -234,7 +234,7 @@ let EmitProperties flavor prefix (emitScope: EmitScope) (i: Browser.Interface)=
         | None -> ()
 
         getAddedItems ItemKind.Property flavor
-        |> Array.filter (matchInterface i.Name)
+        |> Array.filter (fun addedItem -> (matchInterface i.Name addedItem) && (prefix <> "declare var " || not(OptionCheckValue false addedItem.ExposeGlobally)))
         |> Array.iter emitPropertyFromJson
 
 let EmitMethods flavor prefix (emitScope: EmitScope) (i: Browser.Interface) =

--- a/inputfiles/sample.json
+++ b/inputfiles/sample.json
@@ -2,6 +2,7 @@
     {
         "kind": "property",
         "interface": "Window",
+        "exposeGlobally": false,
         "name": "URL",
         "type": "URL"
     },


### PR DESCRIPTION
For the `window` interface, we normally expose every property of it to the top level using `declare var`. However in rare cases where the property was added from external source, while it was already declared as a constructor function, so emitting again will cause issues. 

Related: PR #58 