### PR TITLE
flesh out webcrypto

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4,7 +4,7 @@
 /////////////////////////////
 
 interface Algorithm {
-    name?: string;
+    name: string;
 }
 
 interface AriaRequestEventInit extends EventInit {
@@ -11478,18 +11478,24 @@ declare var StyleSheetPageList: {
 }
 
 interface SubtleCrypto {
-    decrypt(algorithm: string | Algorithm, key: CryptoKey, data: ArrayBufferView): PromiseLike<any>;
-    deriveBits(algorithm: string | Algorithm, baseKey: CryptoKey, length: number): PromiseLike<any>;
-    deriveKey(algorithm: string | Algorithm, baseKey: CryptoKey, derivedKeyType: string | Algorithm, extractable: boolean, keyUsages: string[]): PromiseLike<any>;
-    digest(algorithm: string | Algorithm, data: ArrayBufferView): PromiseLike<any>;
-    encrypt(algorithm: string | Algorithm, key: CryptoKey, data: ArrayBufferView): PromiseLike<any>;
-    exportKey(format: string, key: CryptoKey): PromiseLike<any>;
-    generateKey(algorithm: string | Algorithm, extractable: boolean, keyUsages: string[]): PromiseLike<any>;
-    importKey(format: string, keyData: ArrayBufferView, algorithm: string | Algorithm | null, extractable: boolean, keyUsages: string[]): PromiseLike<any>;
-    sign(algorithm: string | Algorithm, key: CryptoKey, data: ArrayBufferView): PromiseLike<any>;
-    unwrapKey(format: string, wrappedKey: ArrayBufferView, unwrappingKey: CryptoKey, unwrapAlgorithm: string | Algorithm, unwrappedKeyAlgorithm: string | Algorithm | null, extractable: boolean, keyUsages: string[]): PromiseLike<any>;
-    verify(algorithm: string | Algorithm, key: CryptoKey, signature: ArrayBufferView, data: ArrayBufferView): PromiseLike<any>;
-    wrapKey(format: string, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: string | Algorithm): PromiseLike<any>;
+    decrypt(algorithm: string | RsaOaepParams | AesCtrParams | AesCbcParams | AesCmacParams | AesGcmParams | AesCfbParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>;
+    deriveBits(algorithm: string | EcdhKeyDeriveParams | DhKeyDeriveParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, baseKey: CryptoKey, length: number): PromiseLike<ArrayBuffer>;
+    deriveKey(algorithm: string | EcdhKeyDeriveParams | DhKeyDeriveParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: string | AesDerivedKeyParams | HmacImportParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    digest(algorithm: AlgorithmIdentifier, data: BufferSource): PromiseLike<ArrayBuffer>;
+    encrypt(algorithm: string | RsaOaepParams | AesCtrParams | AesCbcParams | AesCmacParams | AesGcmParams | AesCfbParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>;
+    exportKey(format: "jwk", key: CryptoKey): PromiseLike<JsonWebKey>;
+    exportKey(format: "raw" | "pkcs8" | "spki", key: CryptoKey): PromiseLike<ArrayBuffer>;
+    exportKey(format: string, key: CryptoKey): PromiseLike<JsonWebKey | ArrayBuffer>;
+    generateKey(algorithm: string, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKeyPair | CryptoKey>;
+    generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams | DhKeyGenParams, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKeyPair>;
+    generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    importKey(format: "jwk", keyData: JsonWebKey, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    importKey(format: "raw" | "pkcs8" | "spki", keyData: BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    importKey(format: string, keyData: JsonWebKey | BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    sign(algorithm: string | RsaPssParams | EcdsaParams | AesCmacParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>;
+    unwrapKey(format: string, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AlgorithmIdentifier, unwrappedKeyAlgorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>;
+    verify(algorithm: string | RsaPssParams | EcdsaParams | AesCmacParams, key: CryptoKey, signature: BufferSource, data: BufferSource): PromiseLike<boolean>;
+    wrapKey(format: string, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AlgorithmIdentifier): PromiseLike<ArrayBuffer>;
 }
 
 declare var SubtleCrypto: {
@@ -13673,6 +13679,177 @@ interface ClipboardEventInit extends EventInit {
 interface IDBArrayKey extends Array<IDBValidKey> {
 }
 
+interface RsaKeyGenParams extends Algorithm {
+    modulusLength: number;
+    publicExponent: Uint8Array;
+}
+
+interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaKeyAlgorithm extends KeyAlgorithm {
+    modulusLength: number;
+    publicExponent: Uint8Array;
+}
+
+interface RsaHashedKeyAlgorithm extends RsaKeyAlgorithm {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaHashedImportParams {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaPssParams {
+    saltLength: number;
+}
+
+interface RsaOaepParams extends Algorithm {
+    label?: BufferSource;
+}
+
+interface EcdsaParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+}
+
+interface EcKeyGenParams extends Algorithm {
+    typedCurve: string;
+}
+
+interface EcKeyAlgorithm extends KeyAlgorithm {
+    typedCurve: string;
+}
+
+interface EcKeyImportParams {
+    namedCurve: string;
+}
+
+interface EcdhKeyDeriveParams extends Algorithm {
+    public: CryptoKey;
+}
+
+interface AesCtrParams extends Algorithm {
+    counter: BufferSource;
+    length: number;
+}
+
+interface AesKeyAlgorithm extends KeyAlgorithm {
+    length: number;
+}
+
+interface AesKeyGenParams extends Algorithm {
+    length: number;
+}
+
+interface AesDerivedKeyParams extends Algorithm {
+    length: number;
+}
+
+interface AesCbcParams extends Algorithm {
+    iv: BufferSource;
+}
+
+interface AesCmacParams extends Algorithm {
+    length: number;
+}
+
+interface AesGcmParams extends Algorithm {
+    iv: BufferSource;
+    additionalData?: BufferSource;
+    tagLength?: number;
+}
+
+interface AesCfbParams extends Algorithm {
+    iv: BufferSource;
+}
+
+interface HmacImportParams extends Algorithm {
+    hash?: AlgorithmIdentifier;
+    length?: number;
+}
+
+interface HmacKeyAlgorithm extends KeyAlgorithm {
+    hash: AlgorithmIdentifier;
+    length: number;
+}
+
+interface HmacKeyGenParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+    length?: number;
+}
+
+interface DhKeyGenParams extends Algorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface DhKeyAlgorithm extends KeyAlgorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface DhKeyDeriveParams extends Algorithm {
+    public: CryptoKey;
+}
+
+interface DhImportKeyParams extends Algorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface ConcatParams extends Algorithm {
+    hash?: AlgorithmIdentifier;
+    algorithmId: Uint8Array;
+    partyUInfo: Uint8Array;
+    partyVInfo: Uint8Array;
+    publicInfo?: Uint8Array;
+    privateInfo?: Uint8Array;
+}
+
+interface HkdfCtrParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+    label: BufferSource;
+    context: BufferSource;
+}
+
+interface Pbkdf2Params extends Algorithm {
+    salt: BufferSource;
+    iterations: number;
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaOtherPrimesInfo {
+    r: string;
+    d: string;
+    t: string;
+}
+
+interface JsonWebKey {
+    kty: string;
+    use?: string;
+    key_ops?: string[];
+    alg?: string;
+    kid?: string;
+    x5u?: string;
+    x5c?: string;
+    x5t?: string;
+    ext?: boolean;
+    crv?: string;
+    x?: string;
+    y?: string;
+    d?: string;
+    n?: string;
+    e?: string;
+    p?: string;
+    q?: string;
+    dp?: string;
+    dq?: string;
+    qi?: string;
+    oth?: RsaOtherPrimesInfo[];
+    k?: string;
+}
+
 declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 
 interface ErrorEventHandler {
@@ -14043,3 +14220,4 @@ type RTCIceGatherCandidate = RTCIceCandidate | RTCIceCandidateComplete;
 type RTCTransport = RTCDtlsTransport | RTCSrtpSdesTransport;
 type payloadtype = number;
 type IDBValidKey = number | string | Date | IDBArrayKey;
+type BufferSource = ArrayBuffer | ArrayBufferView;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -942,6 +942,177 @@ interface ProgressEventInit extends EventInit {
 interface IDBArrayKey extends Array<IDBValidKey> {
 }
 
+interface RsaKeyGenParams extends Algorithm {
+    modulusLength: number;
+    publicExponent: Uint8Array;
+}
+
+interface RsaHashedKeyGenParams extends RsaKeyGenParams {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaKeyAlgorithm extends KeyAlgorithm {
+    modulusLength: number;
+    publicExponent: Uint8Array;
+}
+
+interface RsaHashedKeyAlgorithm extends RsaKeyAlgorithm {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaHashedImportParams {
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaPssParams {
+    saltLength: number;
+}
+
+interface RsaOaepParams extends Algorithm {
+    label?: BufferSource;
+}
+
+interface EcdsaParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+}
+
+interface EcKeyGenParams extends Algorithm {
+    typedCurve: string;
+}
+
+interface EcKeyAlgorithm extends KeyAlgorithm {
+    typedCurve: string;
+}
+
+interface EcKeyImportParams {
+    namedCurve: string;
+}
+
+interface EcdhKeyDeriveParams extends Algorithm {
+    public: CryptoKey;
+}
+
+interface AesCtrParams extends Algorithm {
+    counter: BufferSource;
+    length: number;
+}
+
+interface AesKeyAlgorithm extends KeyAlgorithm {
+    length: number;
+}
+
+interface AesKeyGenParams extends Algorithm {
+    length: number;
+}
+
+interface AesDerivedKeyParams extends Algorithm {
+    length: number;
+}
+
+interface AesCbcParams extends Algorithm {
+    iv: BufferSource;
+}
+
+interface AesCmacParams extends Algorithm {
+    length: number;
+}
+
+interface AesGcmParams extends Algorithm {
+    iv: BufferSource;
+    additionalData?: BufferSource;
+    tagLength?: number;
+}
+
+interface AesCfbParams extends Algorithm {
+    iv: BufferSource;
+}
+
+interface HmacImportParams extends Algorithm {
+    hash?: AlgorithmIdentifier;
+    length?: number;
+}
+
+interface HmacKeyAlgorithm extends KeyAlgorithm {
+    hash: AlgorithmIdentifier;
+    length: number;
+}
+
+interface HmacKeyGenParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+    length?: number;
+}
+
+interface DhKeyGenParams extends Algorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface DhKeyAlgorithm extends KeyAlgorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface DhKeyDeriveParams extends Algorithm {
+    public: CryptoKey;
+}
+
+interface DhImportKeyParams extends Algorithm {
+    prime: Uint8Array;
+    generator: Uint8Array;
+}
+
+interface ConcatParams extends Algorithm {
+    hash?: AlgorithmIdentifier;
+    algorithmId: Uint8Array;
+    partyUInfo: Uint8Array;
+    partyVInfo: Uint8Array;
+    publicInfo?: Uint8Array;
+    privateInfo?: Uint8Array;
+}
+
+interface HkdfCtrParams extends Algorithm {
+    hash: AlgorithmIdentifier;
+    label: BufferSource;
+    context: BufferSource;
+}
+
+interface Pbkdf2Params extends Algorithm {
+    salt: BufferSource;
+    iterations: number;
+    hash: AlgorithmIdentifier;
+}
+
+interface RsaOtherPrimesInfo {
+    r: string;
+    d: string;
+    t: string;
+}
+
+interface JsonWebKey {
+    kty: string;
+    use?: string;
+    key_ops?: string[];
+    alg?: string;
+    kid?: string;
+    x5u?: string;
+    x5c?: string;
+    x5t?: string;
+    ext?: boolean;
+    crv?: string;
+    x?: string;
+    y?: string;
+    d?: string;
+    n?: string;
+    e?: string;
+    p?: string;
+    q?: string;
+    dp?: string;
+    dq?: string;
+    qi?: string;
+    oth?: RsaOtherPrimesInfo[];
+    k?: string;
+}
+
 declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 
 interface ErrorEventHandler {
@@ -1003,3 +1174,4 @@ declare function addEventListener(type: "message", listener: (ev: MessageEvent) 
 declare function addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 type IDBKeyPath = string;
 type IDBValidKey = number | string | Date | IDBArrayKey;
+type BufferSource = ArrayBuffer | ArrayBufferView;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -412,5 +412,529 @@
         "interface": "CanvasRenderingContext2D",
         "name": "oImageSmoothingEnabled",
         "type": "boolean"
+    },
+    {
+        "kind": "typedef",
+        "name": "BufferSource",
+        "type": "ArrayBuffer | ArrayBufferView"
+    },
+    {
+        "kind": "interface",
+        "name": "RsaKeyGenParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "modulusLength",
+                "type": "number"
+            },
+            {
+                "name": "publicExponent",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaHashedKeyGenParams",
+        "extends": "RsaKeyGenParams",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaKeyAlgorithm",
+        "extends": "KeyAlgorithm",
+        "properties": [
+            {
+                "name": "modulusLength",
+                "type": "number"
+            },
+            {
+                "name": "publicExponent",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaHashedKeyAlgorithm",
+        "extends": "RsaKeyAlgorithm",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaHashedImportParams",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaPssParams",
+        "properties": [
+            {
+                "name": "saltLength",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaOaepParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "label?",
+                "type": "BufferSource"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "EcdsaParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "EcKeyGenParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "typedCurve",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "EcKeyAlgorithm",
+        "extends": "KeyAlgorithm",
+        "properties": [
+            {
+                "name": "typedCurve",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "EcKeyImportParams",
+        "properties": [
+            {
+                "name": "namedCurve",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "EcdhKeyDeriveParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "public",
+                "type": "CryptoKey"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesCtrParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "counter",
+                "type": "BufferSource"
+            },
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesKeyAlgorithm",
+        "extends": "KeyAlgorithm",
+        "properties": [
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesKeyGenParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesDerivedKeyParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesCbcParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "iv",
+                "type": "BufferSource"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesCmacParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesGcmParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "iv",
+                "type": "BufferSource"
+            },
+            {
+                "name": "additionalData?",
+                "type": "BufferSource"
+            },
+            {
+                "name": "tagLength?",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "AesCfbParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "iv",
+                "type": "BufferSource"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "HmacImportParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "hash?",
+                "type": "AlgorithmIdentifier"
+            },
+            {
+                "name": "length?",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "HmacKeyAlgorithm",
+        "extends": "KeyAlgorithm",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            },
+            {
+                "name": "length",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "HmacKeyGenParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            },
+            {
+                "name": "length?",
+                "type": "number"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "DhKeyGenParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "prime",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "generator",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "DhKeyAlgorithm",
+        "extends": "KeyAlgorithm",
+        "properties": [
+            {
+                "name": "prime",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "generator",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "DhKeyDeriveParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "public",
+                "type": "CryptoKey"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "DhImportKeyParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "prime",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "generator",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "ConcatParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "hash?",
+                "type": "AlgorithmIdentifier"
+            },
+            {
+                "name": "algorithmId",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "partyUInfo",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "partyVInfo",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "publicInfo?",
+                "type": "Uint8Array"
+            },
+            {
+                "name": "privateInfo?",
+                "type": "Uint8Array"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "HkdfCtrParams",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            },
+            {
+                "name": "label",
+                "type": "BufferSource"
+            },
+            {
+                "name": "context",
+                "type": "BufferSource"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "Pbkdf2Params",
+        "extends": "Algorithm",
+        "properties": [
+            {
+                "name": "salt",
+                "type": "BufferSource"
+            },
+            {
+                "name": "iterations",
+                "type": "number"
+            },
+            {
+                "name": "hash",
+                "type": "AlgorithmIdentifier"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "RsaOtherPrimesInfo",
+        "properties": [
+            {
+                "name": "r",
+                "type": "string"
+            },
+            {
+                "name": "d",
+                "type": "string"
+            },
+            {
+                "name": "t",
+                "type": "string"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "JsonWebKey",
+        "properties": [
+            {
+                "name": "kty",
+                "type": "string"
+            },
+            {
+                "name": "use?",
+                "type": "string"
+            },
+            {
+                "name": "key_ops?",
+                "type": "string[]"
+            },
+            {
+                "name": "alg?",
+                "type": "string"
+            },
+            {
+                "name": "kid?",
+                "type": "string"
+            },
+            {
+                "name": "x5u?",
+                "type": "string"
+            },
+            {
+                "name": "x5c?",
+                "type": "string"
+            },
+            {
+                "name": "x5t?",
+                "type": "string"
+            },
+            {
+                "name": "ext?",
+                "type": "boolean"
+            },
+            {
+                "name": "crv?",
+                "type": "string"
+            },
+            {
+                "name": "x?",
+                "type": "string"
+            },
+            {
+                "name": "y?",
+                "type": "string"
+            },
+            {
+                "name": "d?",
+                "type": "string"
+            },
+            {
+                "name": "n?",
+                "type": "string"
+            },
+            {
+                "name": "e?",
+                "type": "string"
+            },
+            {
+                "name": "p?",
+                "type": "string"
+            },
+            {
+                "name": "q?",
+                "type": "string"
+            },
+            {
+                "name": "dp?",
+                "type": "string"
+            },
+            {
+                "name": "dq?",
+                "type": "string"
+            },
+            {
+                "name": "qi?",
+                "type": "string"
+            },
+            {
+                "name": "oth?",
+                "type": "RsaOtherPrimesInfo[]"
+            },
+            {
+                "name": "k?",
+                "type": "string"
+            }
+        ]
     }
 ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -694,5 +694,95 @@
         "kind": "extends",
         "baseInterface": "HTMLCollectionOf<HTMLOptionElement>",
         "interface": "HTMLOptionsCollection"
-    }
-]
+    },
+     {
+         "kind": "property",
+         "interface": "Algorithm",
+         "name": "name",
+         "type": "string"
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "decrypt",
+         "signatures": ["decrypt(algorithm: string | RsaOaepParams | AesCtrParams | AesCbcParams | AesCmacParams | AesGcmParams | AesCfbParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "deriveBits",
+         "signatures": ["deriveBits(algorithm: string | EcdhKeyDeriveParams | DhKeyDeriveParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, baseKey: CryptoKey, length: number): PromiseLike<ArrayBuffer>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "deriveKey",
+         "signatures": ["deriveKey(algorithm: string | EcdhKeyDeriveParams | DhKeyDeriveParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, baseKey: CryptoKey, derivedKeyType: string | AesDerivedKeyParams | HmacImportParams | ConcatParams | HkdfCtrParams | Pbkdf2Params, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "digest",
+         "signatures": ["digest(algorithm: AlgorithmIdentifier, data: BufferSource): PromiseLike<ArrayBuffer>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "encrypt",
+         "signatures": ["encrypt(algorithm: string | RsaOaepParams | AesCtrParams | AesCbcParams | AesCmacParams | AesGcmParams | AesCfbParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "exportKey",
+         "signatures": [
+             "exportKey(format: \"jwk\", key: CryptoKey): PromiseLike<JsonWebKey>",
+             "exportKey(format: \"raw\" | \"pkcs8\" | \"spki\", key: CryptoKey): PromiseLike<ArrayBuffer>",
+             "exportKey(format: string, key: CryptoKey): PromiseLike<JsonWebKey | ArrayBuffer>"
+         ]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "generateKey",
+         "signatures": [
+             "generateKey(algorithm: string, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKeyPair | CryptoKey>",
+             "generateKey(algorithm: RsaHashedKeyGenParams | EcKeyGenParams | DhKeyGenParams, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKeyPair>",
+             "generateKey(algorithm: AesKeyGenParams | HmacKeyGenParams | Pbkdf2Params, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>"
+         ]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "importKey",
+         "signatures": [
+             "importKey(format: \"jwk\", keyData: JsonWebKey, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>",
+             "importKey(format: \"raw\" | \"pkcs8\" | \"spki\", keyData: BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>",
+             "importKey(format: string, keyData: JsonWebKey | BufferSource, algorithm: string | RsaHashedImportParams | EcKeyImportParams | HmacImportParams | DhImportKeyParams, extractable:boolean, keyUsages: string[]): PromiseLike<CryptoKey>"
+         ]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "sign",
+         "signatures": ["sign(algorithm: string | RsaPssParams | EcdsaParams | AesCmacParams, key: CryptoKey, data: BufferSource): PromiseLike<ArrayBuffer>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "unwrapKey",
+         "signatures": ["unwrapKey(format: string, wrappedKey: BufferSource, unwrappingKey: CryptoKey, unwrapAlgorithm: AlgorithmIdentifier, unwrappedKeyAlgorithm: AlgorithmIdentifier, extractable: boolean, keyUsages: string[]): PromiseLike<CryptoKey>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "verify",
+         "signatures": ["verify(algorithm: string | RsaPssParams | EcdsaParams | AesCmacParams, key: CryptoKey, signature: BufferSource, data: BufferSource): PromiseLike<boolean>"]
+     },
+     {
+         "kind": "method",
+         "interface": "SubtleCrypto",
+         "name": "wrapKey",
+         "signatures": ["wrapKey(format: string, key: CryptoKey, wrappingKey: CryptoKey, wrapAlgorithm: AlgorithmIdentifier): PromiseLike<ArrayBuffer>"]
+     }
+ ]


### PR DESCRIPTION
This should, among other things, sort of address [TS issue #3984](https://github.com/Microsoft/TypeScript/issues/3984). Fully making the return type a `Promise` instead of a `PromiseLike` is dependent on some sort of resolution of [the ability to target the ES6 library separately](https://github.com/Microsoft/TSJS-lib-generator/issues/47). Reference document used to create these typings is [the 2014.12 W3C WebCrypto API CR](https://www.w3.org/TR/WebCryptoAPI/).

Generally speaking, this should make code work that used to not compile (such as importing JSON web keys). The only *more* restrictive change, I believe, is making the `name` property of `Algorithm` no longer optional. It is explicitly documented as required in the W3C document.