### PR TITLE
Add 'import' to HTMLLinkElements

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5262,6 +5262,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
       * Sets or retrieves the MIME type of the object.
       */
     type: string;
+    import?: Document;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
 

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -303,8 +303,14 @@
         "interface": "Document",
         "name": "currentScript",
         "type": "HTMLScriptElement"
-     },
-     {
+    },
+    {
+        "kind": "property",
+        "interface": "HTMLLinkElement",
+        "name": "import?",
+        "type": "Document"
+    },
+    {
         "kind": "interface",
         "name": "HTMLTemplateElement",
         "flavor":  "Web",


### PR DESCRIPTION
With HTML Imports, <link> elements now have an 'import' property, providing access to the referenced document.

Spec: https://www.w3.org/TR/html-imports/#interface-import

I've left this optional, since it won't exist at all for browsers that don't support HTML Imports yet, and it's always null for browsers that do if the <link> doesn't have `rel='import'`.