### PR TITLE
Update build.cmd to avoid usage of curl, and to instead shell out to …

### DIFF
--- a/build.cmd
+++ b/build.cmd
@@ -5,7 +5,7 @@ if not exist .paket mkdir .paket
 
 if not exist .paket/paket.bootstrapper.exe (
   @echo "Installing Paket"
-  Powershell.exe -File download.ps1
+  Powershell.exe -Command "Invoke-WebRequest -Uri https://github.com/fsprojects/Paket/releases/download/2.12.5/paket.bootstrapper.exe -OutFile .paket\paket.bootstrapper.exe"
 
 
   .paket\paket.bootstrapper.exe prerelease

--- a/build.cmd
+++ b/build.cmd
@@ -1,10 +1,12 @@
 @echo off
 cls
 
-if not exist .paket (
+if not exist .paket mkdir .paket
+
+if not exist .paket/paket.bootstrapper.exe (
   @echo "Installing Paket"
-  mkdir .paket
-  curl https://github.com/fsprojects/Paket/releases/download/2.12.5/paket.bootstrapper.exe -L --insecure -o .paket\paket.bootstrapper.exe
+  Powershell.exe -File download.ps1
+
 
   .paket\paket.bootstrapper.exe prerelease
   if errorlevel 1 (

--- a/download.ps1
+++ b/download.ps1
@@ -1,1 +1,0 @@
-Invoke-WebRequest -Uri https://github.com/fsprojects/Paket/releases/download/2.12.5/paket.bootstrapper.exe -OutFile .paket\paket.bootstrapper.exe

--- a/download.ps1
+++ b/download.ps1
@@ -1,0 +1,1 @@
+Invoke-WebRequest -Uri https://github.com/fsprojects/Paket/releases/download/2.12.5/paket.bootstrapper.exe -OutFile .paket\paket.bootstrapper.exe


### PR DESCRIPTION
…PowerShell, which uses Invoke-WebRequest.

This fixes issues on systems that either don't have Curl installed, or Curl is not in PATH.