### PR TITLE
Add HTMLFileInputElement and update HTMLInputElement.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5636,9 +5636,9 @@ interface HTMLInputElement extends HTMLElement {
     defaultValue: string;
     disabled: boolean;
     /**
-      * Returns a FileList object on a file type input object.
+      * Returns a FileList object on a file type input object. This is null for all other input objects.
       */
-    files: FileList;
+    files: void;
     /**
       * Retrieves a reference to the form that the object is embedded in. 
       */
@@ -13666,6 +13666,15 @@ interface ClipboardEventInit extends EventInit {
 }
 
 interface IDBArrayKey extends Array<IDBValidKey> {
+}
+
+interface HTMLFileInputElement extends HTMLInputElement {
+    files: FileList;
+}
+
+declare var HTMLFileInputElement: {
+    prototype: HTMLFileInputElement;
+    new(): HTMLFileInputElement;
 }
 
 declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -384,5 +384,20 @@
         "interface": "HTMLTextAreaElement",
         "name": "minLength",
         "type": "number"
+    },
+    {
+        "kind": "interface",
+        "name": "HTMLFileInputElement",
+        "flavor":  "Web",
+        "extends": "HTMLInputElement",
+        "constructorSignatures": [
+            "new(): HTMLFileInputElement"
+        ],
+        "properties": [
+            {
+                "name": "files",
+                "type": "FileList"
+            }
+        ]
     }
 ]

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1862,7 +1862,7 @@
           },
           {
             "name": "files",
-            "comment": "/**\r\n      * Returns a FileList object on a file type input object.\r\n      */"
+            "comment": "/**\r\n      * Returns a FileList object on a file type input object. This is null for all other input objects.\r\n      */"
           },
           {
             "name": "max",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -469,5 +469,11 @@
         "interface": "IDBIndex",
         "name": "getKey",
         "signatures": ["getKey(key: IDBKeyRange | IDBValidKey): IDBRequest"]
+    },
+    {
+        "kind": "property",
+        "interface": "HTMLInputElement",
+        "name": "files",
+        "type": "void"
     }
 ]


### PR DESCRIPTION
This change introduces a new interface for file input elements and updates the "files" object of all other input elements.

The existing "files" object is `undefined` when the input type is not a "file" type. The new interface correctly reflects when the "files" object is a FileList.