### PR TITLE
Add support for extends

### DIFF
--- a/Shared.fsx
+++ b/Shared.fsx
@@ -69,6 +69,7 @@ module JsonItems =
         | Indexer
         | SignatureOverload
         | TypeDef
+        | Extends
         override x.ToString() = (unionToString x).ToLower()
 
     let findItem (allItems: ItemsType.Root []) (itemName: string) (kind: ItemKind) otherFilter =

--- a/TS.fsx
+++ b/TS.fsx
@@ -381,8 +381,15 @@ let EmitNamedConstructors () =
 
 let EmitInterfaceDeclaration (i:Browser.Interface) =
     Pt.printl "interface %s" i.Name
-    match i.Extends::(List.ofArray i.Implements) with
-    | [""] | [] | ["Object"] -> ()
+    let extendsFromSpec =
+        match i.Extends::(List.ofArray i.Implements) with
+        | [""] | [] | ["Object"] -> []
+        | specExtends -> specExtends
+    let extendsFromJson =
+        JsonItems.getAddedItemsByInterfaceName ItemKind.Extends Flavor.All i.Name
+        |> Array.map (fun e -> e.BaseInterface.Value) |> List.ofArray
+    match List.concat [extendsFromSpec; extendsFromJson] with
+    | [] -> ()
     | allExtends -> Pt.print " extends %s" (String.Join(", ", allExtends))
     Pt.print " {"
 

--- a/inputfiles/sample.json
+++ b/inputfiles/sample.json
@@ -330,5 +330,10 @@
         "kind": "typedef",
         "name": "IDBValidKey",
         "type": "number | string | Date | IDBArrayKey"
+    },
+    {
+        "kind": "extends",
+        "baseInterface": "ParentNode",
+        "interface": "Document"
     }
 ]


### PR DESCRIPTION
Help with #66 

Now one can add a base interface to an interface as follows:
```json
    {
        "kind": "extends",
        "baseInterface": "ParentNode",
        "interface": "Document"
    }
```