### PR TITLE
Add CanvasRenderingContext2D.msImageSmoothingEnabled with vender-prefix

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1773,6 +1773,9 @@ interface CanvasRenderingContext2D extends Object, CanvasPathMethods {
     strokeStyle: string | CanvasGradient | CanvasPattern;
     textAlign: string;
     textBaseline: string;
+    mozImageSmoothingEnabled: boolean;
+    webkitImageSmoothingEnabled: boolean;
+    oImageSmoothingEnabled: boolean;
     beginPath(): void;
     clearRect(x: number, y: number, w: number, h: number): void;
     clip(fillRule?: string): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -393,5 +393,23 @@
         "interface": "IDBDatabase",
         "name": "addEventListener",
         "signatures": ["addEventListener(type: \"versionchange\", listener: (ev: IDBVersionChangeEvent) => any, useCapture?: boolean): void"]
+    },
+    {
+        "kind": "property",
+        "interface": "CanvasRenderingContext2D",
+        "name": "mozImageSmoothingEnabled",
+        "type": "boolean"
+    },
+    {
+        "kind": "property",
+        "interface": "CanvasRenderingContext2D",
+        "name": "webkitImageSmoothingEnabled",
+        "type": "boolean"
+    },
+    {
+        "kind": "property",
+        "interface": "CanvasRenderingContext2D",
+        "name": "oImageSmoothingEnabled",
+        "type": "boolean"
     }
 ]


### PR DESCRIPTION
fix: [#7846](https://github.com/Microsoft/TypeScript/issues/7846)
spec: [CanvasRenderingContext2D.imageSmoothingEnabled](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled)