### PR TITLE
Second parameter of insertBefore should accept null

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8738,7 +8738,7 @@ interface Node extends EventTarget {
     contains(child: Node): boolean;
     hasAttributes(): boolean;
     hasChildNodes(): boolean;
-    insertBefore(newChild: Node, refChild: Node): Node;
+    insertBefore(newChild: Node, refChild: Node | null): Node;
     isDefaultNamespace(namespaceURI: string | null): boolean;
     isEqualNode(arg: Node): boolean;
     isSameNode(other: Node): boolean;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -3,7 +3,7 @@
         "kind": "method",
         "interface": "Node",
         "name": "insertBefore",
-        "signatures": ["insertBefore(newChild: Node, refChild: Node): Node"]
+        "signatures": ["insertBefore(newChild: Node, refChild: Node | null): Node"]
     },
     {
         "kind": "method",


### PR DESCRIPTION
According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Node/insertBefore), the second parameter of insertBefore is not optional (which is was fixed in #95), but it can accept `null`. Under `strictNullChecks` this is currently not allowed, this PR fixes that.