### PR TITLE
Add integrity to script and link

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5869,6 +5869,10 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
       */
     hreflang: string;
     /**
+     * Sets or retrieves the integrity hash.
+     */
+    integrity: string;
+    /**
       * Sets or retrieves the media type.
       */
     media: string;
@@ -6730,6 +6734,10 @@ interface HTMLScriptElement extends HTMLElement {
       * Sets or retrieves the status of the script.
       */
     defer: boolean;
+    /**
+     * Sets or retrieves the integrity hash.
+     */
+    integrity: string;
     /**
       * Sets or retrieves the event for which the script is written. 
       */


### PR DESCRIPTION
Reference: https://github.com/Microsoft/TypeScript/issues/8955

This pull-request adds the property `integrity` for the interfaces `HTMLScriptElement` and `HTMLLinkElement` according to [W3 recommendation](https://www.w3.org/TR/SRI/#).

```typescript
let script = document.createElement('script');
script.integrity = "sha-256-some-hash"
```