### PR TITLE
Moved insertAdjacent* methods from HTMLElement interface to parent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3675,6 +3675,9 @@ interface Element extends Node, GlobalEventHandlers, ElementTraversal, NodeSelec
     getElementsByClassName(classNames: string): NodeListOf<Element>;
     matches(selector: string): boolean;
     closest(selector: string): Element | null;
+    insertAdjacentElement(position: string, insertedElement: Element): Element | null;
+    insertAdjacentHTML(where: string, html: string): void;
+    insertAdjacentText(where: string, text: string): void;
     addEventListener(type: "MSGestureChange", listener: (this: this, ev: MSGestureEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "MSGestureDoubleTap", listener: (this: this, ev: MSGestureEvent) => any, useCapture?: boolean): void;
     addEventListener(type: "MSGestureEnd", listener: (this: this, ev: MSGestureEvent) => any, useCapture?: boolean): void;
@@ -4621,9 +4624,6 @@ interface HTMLElement extends Element {
     click(): void;
     dragDrop(): boolean;
     focus(): void;
-    insertAdjacentElement(position: string, insertedElement: Element): Element;
-    insertAdjacentHTML(where: string, html: string): void;
-    insertAdjacentText(where: string, text: string): void;
     msGetInputContext(): MSInputMethodContext;
     scrollIntoView(top?: boolean): void;
     setActive(): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -984,5 +984,23 @@
         "name": "MouseWheelEvent",
         "flavor": "Web",
         "type": "WheelEvent"
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentElement",
+        "signatures": ["insertAdjacentElement(position: string, insertedElement: Element): Element | null"]
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentHTML",
+        "signatures": ["insertAdjacentHTML(where: string, html: string): void"]
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentText",
+        "signatures": ["insertAdjacentText(where: string, text: string): void"]
     }
 ]

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -48,5 +48,20 @@
         "kind": "property",
         "interface": "XMLHttpRequest",
         "name": "msCaching"
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLElement",
+        "name": "insertAdjacentElement"
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLElement",
+        "name": "insertAdjacentHTML"
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLElement",
+        "name": "insertAdjacentText"
     }
 ]


### PR DESCRIPTION
According to the MDN (https://developer.mozilla.org/en-US/docs/Web/API/Element), insertAdjacent* methods should be part of the Element interface.

Issue: #130 