### PR TITLE
Add `type` argument on toBlob()

### DIFF
--- a/TS.fsx
+++ b/TS.fsx
@@ -568,7 +568,7 @@ let EmitStaticInterface flavor (i:Browser.Interface) =
     // interface, and put the static members into the object literal type of 'declare var'
     // For static types with only static members, we put everything in the interface.
     // Because in the two cases the interface contains different things, it might be easier to
-    // read to seperate them into two functions.
+    // read to separate them into two functions.
     let emitStaticInterfaceWithNonStaticMembers () =
         Pt.resetIndent()
         EmitInterfaceDeclaration i

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4446,7 +4446,7 @@ interface HTMLCanvasElement extends HTMLElement {
       * @param type The standard MIME type for the image format to return. If you do not specify this parameter, the default value is a PNG format image.
       */
     toDataURL(type?: string, ...args: any[]): string;
-    toBlob(callback: (result: Blob | null) => void, ... arguments: any[]): void;
+    toBlob(callback: (result: Blob | null) => void, type?: string, ...arguments: any[]): void;
 }
 
 declare var HTMLCanvasElement: {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -343,7 +343,7 @@
         "kind": "method",
         "interface": "HTMLCanvasElement",
         "name": "toBlob",
-        "signatures": ["toBlob(callback: (result: Blob | null) => void, ... arguments: any[]): void"]
+        "signatures": ["toBlob(callback: (result: Blob | null) => void, type?: string, ...arguments: any[]): void"]
     },
     {
         "kind": "property",


### PR DESCRIPTION
http://www.w3.org/TR/html5/scripting-1.html#the-canvas-element

```webidl
typedef (CanvasRenderingContext2D or WebGLRenderingContext) RenderingContext;

interface HTMLCanvasElement : HTMLElement {
           attribute unsigned long width;
           attribute unsigned long height;

  RenderingContext? getContext(DOMString contextId, any... arguments);

  DOMString toDataURL(optional DOMString type, any... arguments);
  void toBlob(FileCallback? _callback, optional DOMString type, any... arguments);
};
```