### PR TITLE
Add secureConnectionStart property for PerformanceTiming interface

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -9134,6 +9134,7 @@ interface PerformanceTiming {
     readonly responseStart: number;
     readonly unloadEventEnd: number;
     readonly unloadEventStart: number;
+    readonly secureConnectionStart: number;
     toJSON(): any;
 }
 

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1101,5 +1101,12 @@
         "interface": "Element",
         "name": "insertAdjacentText",
         "signatures": ["insertAdjacentText(where: string, text: string): void"]
+    },
+    {
+        "kind": "property",
+        "name": "secureConnectionStart",
+        "interface": "PerformanceTiming",
+        "readonly": true,
+        "type": "number"
     }
 ]


### PR DESCRIPTION
fix [#9698](https://github.com/Microsoft/TypeScript/issues/9698)