### PR TITLE
changed EcKeyGenParams from typedCurve to namedCurve to fix issue

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14098,7 +14098,7 @@ interface EcdsaParams extends Algorithm {
 }
 
 interface EcKeyGenParams extends Algorithm {
-    typedCurve: string;
+    namedCurve: string;
 }
 
 interface EcKeyAlgorithm extends KeyAlgorithm {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1000,7 +1000,7 @@ interface EcdsaParams extends Algorithm {
 }
 
 interface EcKeyGenParams extends Algorithm {
-    typedCurve: string;
+    namedCurve: string;
 }
 
 interface EcKeyAlgorithm extends KeyAlgorithm {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -653,7 +653,7 @@
         "extends": "Algorithm",
         "properties": [
             {
-                "name": "typedCurve",
+                "name": "namedCurve",
                 "type": "string"
             }
         ]


### PR DESCRIPTION
If you leave the parameters named typedCurve it compiles clean but when run in the browser (Chrome 51) it fails with the following error Uncaught (in promise) TypeError: EcKeyGenParams: namedCurve: Missing or not a string(…).

If you change it to namedCurve tsc will have an error but the generated code runs without issue. 

This pull request should fix this so that you have clean compilation and error free generated code.