### PR TITLE
Added missing property code to interface KeyboardEvent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7764,6 +7764,7 @@ interface KeyboardEvent extends UIEvent {
     readonly repeat: boolean;
     readonly shiftKey: boolean;
     readonly which: number;
+    readonly code: string;
     getModifierState(keyArg: string): boolean;
     initKeyboardEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, viewArg: Window, keyArg: string, locationArg: number, modifiersListArg: string, repeat: boolean, locale: string): void;
     readonly DOM_KEY_LOCATION_JOYSTICK: number;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1120,5 +1120,12 @@
         "interface": "HTMLScriptElement",
         "name": "integrity",
         "type": "string"
+    },
+    {
+        "kind": "property",
+        "interface": "KeyboardEvent",
+        "readonly": true,
+        "name": "code",
+        "type": "string"
     }
 ]


### PR DESCRIPTION
This addresses issue [9206](https://github.com/Microsoft/TypeScript/issues/9206) in TypeScript.

It adds the missing code[1][2][3] property to interface KeyboardEvent.

[1] https://www.w3.org/TR/uievents/#keys-codevalues
[2] https://w3c.github.io/uievents/#keys-codevalues
[3] https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code