### PR TITLE
Added missing property code to interface KeyboardEventInit

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -126,6 +126,7 @@ interface KeyAlgorithm {
 }
 
 interface KeyboardEventInit extends EventModifierInit {
+    code?: string;
     key?: string;
     location?: number;
     repeat?: boolean;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1127,5 +1127,11 @@
         "readonly": true,
         "name": "code",
         "type": "string"
+    },
+    {
+        "kind": "property",
+        "interface": "KeyboardEventInit",
+        "name": "code?",
+        "type": "string"
     }
 ]


### PR DESCRIPTION
Completing the work of [pull request 136](https://github.com/Microsoft/TSJS-lib-generator/pull/136)

This addresses issue https://github.com/Microsoft/TypeScript/issues/9206 in TypeScript.

It adds the missing code[1][2][3] property to interface KeyboardEventInit.

[1] https://www.w3.org/TR/uievents/#keys-codevalues
[2] https://w3c.github.io/uievents/#keys-codevalues
[3] https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code