### PR TITLE
fix window.opener property

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12958,7 +12958,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     onunload: (this: this, ev: Event) => any;
     onvolumechange: (this: this, ev: Event) => any;
     onwaiting: (this: this, ev: Event) => any;
-    readonly opener: Window;
+    opener: any;
     orientation: string | number;
     readonly outerHeight: number;
     readonly outerWidth: number;
@@ -14407,7 +14407,7 @@ declare var ontouchstart: (ev: TouchEvent) => any;
 declare var onunload: (this: Window, ev: Event) => any;
 declare var onvolumechange: (this: Window, ev: Event) => any;
 declare var onwaiting: (this: Window, ev: Event) => any;
-declare var opener: Window;
+declare var opener: any;
 declare var orientation: string | number;
 declare var outerHeight: number;
 declare var outerWidth: number;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -809,5 +809,11 @@
          "readonly": true,
          "name": "files",
          "type": "FileList | null"
+     },
+     {
+         "kind": "property",
+         "interface": "Window",
+         "name": "opener",
+         "type": "any"
      }
  ]


### PR DESCRIPTION
fix [2.0: window.opener declared as readonly #10379](https://github.com/Microsoft/TypeScript/issues/10379)
I follow [w3c spec](https://w3c.github.io/html/browsers.html#the-window-object)