### PR TITLE
Remove number indexer declaration on window object.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13113,7 +13113,6 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     addEventListener(type: "waiting", listener: (this: this, ev: Event) => any, useCapture?: boolean): void;
     addEventListener(type: "wheel", listener: (this: this, ev: WheelEvent) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
-    [index: number]: Window;
 }
 
 declare var Window: {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -68,5 +68,10 @@
         "kind": "method",
         "interface": "HTMLElement",
         "name": "insertAdjacentText"
+    },
+    {
+        "kind": "indexer",
+        "interface": "Window",
+        "signatures": [ "[index: number]: Window" ]
     }
 ]


### PR DESCRIPTION
This allows string indexing to be preferred which is the typical expectation for the window object.  Fixes TypeScript issue #10457