### PR TITLE
evaluate should allow null for resolver and result

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13226,7 +13226,7 @@ declare var XPathEvaluator: {
 }
 
 interface XPathExpression {
-    evaluate(contextNode: Node, type: number, result: XPathResult): XPathExpression;
+    evaluate(contextNode: Node, type: number, result: XPathResult | null): XPathResult;
 }
 
 declare var XPathExpression: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2969,7 +2969,7 @@ interface Document extends Node, GlobalEventHandlers, NodeSelector, DocumentEven
       * @param y The y-offset
       */
     elementFromPoint(x: number, y: number): Element;
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver, type: number, result: XPathResult): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
     /**
       * Executes a command on the current document, current selection, or the given range.
       * @param commandId String that specifies the command to execute. This command can be any of the command identifiers that can be executed in script.
@@ -13217,7 +13217,7 @@ declare var XMLSerializer: {
 interface XPathEvaluator {
     createExpression(expression: string, resolver: XPathNSResolver): XPathExpression;
     createNSResolver(nodeResolver?: Node): XPathNSResolver;
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver, type: number, result: XPathResult): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
 }
 
 declare var XPathEvaluator: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -918,5 +918,11 @@
         "interface": "Document",
         "name": "evaluate",
         "signatures": ["evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"]
+    },
+    {
+        "kind": "method",
+        "interface": "XPathExpression",
+        "name": "evaluate",
+        "signatures": ["evaluate(contextNode: Node, type: number, result: XPathResult | null): XPathResult"]
     }
  ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -906,5 +906,17 @@
         "readonly": true,
         "name": "types",
         "type": "string[]"
+    },
+    {
+        "kind": "method",
+        "interface": "XPathEvaluator",
+        "name": "evaluate",
+        "signatures": ["evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"]
+    },
+    {
+        "kind": "method",
+        "interface": "Document",
+        "name": "evaluate",
+        "signatures": ["evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"]
     }
  ]


### PR DESCRIPTION
This should fix https://github.com/Microsoft/TypeScript/issues/11981 

I've also changed the return type of `XPathExpression.evaluate` to `XPathResult` based on https://developer.mozilla.org/en-US/docs/Web/API/XPathExpression