### PR TITLE
Correct signature of ErrorEvent constructor

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3320,7 +3320,7 @@ interface ErrorEvent extends Event {
 
 declare var ErrorEvent: {
     prototype: ErrorEvent;
-    new(): ErrorEvent;
+    new(type: string, errorEventInitDict?: ErrorEventInit): ErrorEvent;
 }
 
 interface Event {
@@ -12706,6 +12706,14 @@ interface XMLHttpRequestEventTarget {
     ontimeout: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
     addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(type: K, listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+}
+
+interface ErrorEventInit {
+    message?: string;
+    filename?: string;
+    lineno?: number;
+    conlno?: number;
+    error?: any;
 }
 
 interface StorageEventInit extends EventInit {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -227,7 +227,7 @@ interface ErrorEvent extends Event {
 
 declare var ErrorEvent: {
     prototype: ErrorEvent;
-    new(): ErrorEvent;
+    new(type: string, errorEventInitDict?: ErrorEventInit): ErrorEvent;
 }
 
 interface Event {
@@ -983,6 +983,14 @@ interface WorkerUtils extends Object, WindowBase64 {
     setInterval(handler: any, timeout?: any, ...args: any[]): number;
     setTimeout(handler: (...args: any[]) => void, timeout: number): number;
     setTimeout(handler: any, timeout?: any, ...args: any[]): number;
+}
+
+interface ErrorEventInit {
+    message?: string;
+    filename?: string;
+    lineno?: number;
+    conlno?: number;
+    error?: any;
 }
 
 interface BlobPropertyBag {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1,5 +1,31 @@
 [
     {
+        "kind": "interface",
+        "name": "ErrorEventInit",
+        "properties": [
+            {
+                "name": "message?",
+                "type": "string"
+            },
+            {
+                "name": "filename?",
+                "type": "string"
+            },
+            {
+                "name": "lineno?",
+                "type": "number"
+            },
+            {
+                "name": "conlno?",
+                "type": "number"
+            },
+            {
+                "name": "error?",
+                "type": "any"
+            }
+        ]
+    },
+    {
         "kind": "property",
         "interface": "CSSStyleDeclaration",
         "name": "resize",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1,5 +1,10 @@
  [
     {
+        "kind": "constructor",
+        "interface": "ErrorEvent",
+        "signatures": ["new(type: string, errorEventInitDict?: ErrorEventInit): ErrorEvent"]
+    },
+    {
         "kind": "property",
         "interface": "Window",
         "name": "event",


### PR DESCRIPTION
According to the spec
https://html.spec.whatwg.org/multipage/webappapis.html#the-errorevent-interface
ErrorEvent constructor accept some params

This fixes https://github.com/Microsoft/TypeScript/issues/12644