### PR TITLE
Fix build error

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12981,8 +12981,8 @@ interface JsonWebKey {
 
 interface ParentNode {
     readonly children: HTMLCollection;
-    readonly firstElementChild: Element;
-    readonly lastElementChild: Element;
+    readonly firstElementChild: Element | null;
+    readonly lastElementChild: Element | null;
     readonly childElementCount: number;
 }
 

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1234,12 +1234,12 @@
             {
                 "name": "firstElementChild",
                 "readonly": true,
-                "type": "Element"
+                "type": "Element | null"
             },
             {
                 "name": "lastElementChild",
                 "readonly": true,
-                "type": "Element"
+                "type": "Element | null"
             },
             {
                 "name": "childElementCount",


### PR DESCRIPTION
Build was broken because `Element` inherits from both `ElementTraversal` and `ParentNode`, while a recent PR made two properties from `ElementTraversal` nullable, so TS complains these properties have different types in different base types. 

Related spec:
https://dom.spec.whatwg.org/#dom-parentnode-firstelementchild
The `firstElementChild` and `lastElementChild` are indeed nuallble as well in `ParentNode` interface.