### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/13269: Make `DataTransfer.types` a `DOMString[]`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2189,7 +2189,7 @@ interface DataTransfer {
     effectAllowed: string;
     readonly files: FileList;
     readonly items: DataTransferItemList;
-    readonly types: string[];
+    readonly types: DOMString[];
     clearData(format?: string): boolean;
     getData(format: string): string;
     setData(format: string, data: string): boolean;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -910,7 +910,7 @@
         "interface": "DataTransfer",
         "readonly": true,
         "name": "types",
-        "type": "string[]"
+        "type": "DOMString[]"
     },
     {
         "kind": "method",


### PR DESCRIPTION
According to the spec: https://html.spec.whatwg.org/multipage/interaction.html#datatransfer
`types` is `DOMString[]` and not `string[]`.


Fixes https://github.com/Microsoft/TypeScript/issues/13269
//cc: @falsandtru 