### PR TITLE
Fix lack of undefined for DOMStringMap indexer

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2491,7 +2491,7 @@ declare var DOMStringList: {
 }
 
 interface DOMStringMap {
-    [name: string]: string;
+    [name: string]: string | undefined;
 }
 
 declare var DOMStringMap: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -980,5 +980,10 @@
         "readonly": true,
         "name": "previousElementSibling",
         "type": "Element | null"
+    },
+    {
+        "kind": "indexer",
+        "interface": "DOMStringMap",
+        "signatures": ["[name: string]: string | undefined"]
     }
  ]


### PR DESCRIPTION
Fixes: https://github.com/Microsoft/TypeScript/issues/13792

Currently, the DOMStringMap interface doesn't respect that elements in the map may be undefined. This makes it easy to result in type errors around its usage.

This PR adds a union with the `undefined` type to the elements in order to accurately reflect its possible runtime types.