### PR TITLE
web audio api : fix AudioNode.connect

### DIFF
--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -496,6 +496,12 @@
         ]
     },
     {
+        "kind": "method",
+        "interface": "AudioNode",
+        "name": "connect",
+        "signatures": ["connect(destination: AudioNode|AudioParam, output?: number, input?: number): void"]
+    },
+    {
         "kind": "callback",
         "name": "DecodeErrorCallback",
         "signatures": ["(error: DOMException): void"]


### PR DESCRIPTION
AudioNode.connect should be able to connect to both AudioNode and AudioParam 
https://developer.mozilla.org/en-US/docs/Web/API/AudioNode/connect(AudioParam)