### PR TITLE
Fix DOMImplementation.createDocument signature

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2449,7 +2449,7 @@ declare var DOMException: {
 }
 
 interface DOMImplementation {
-    createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType): Document;
+    createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document;
     createDocumentType(qualifiedName: string, publicId: string, systemId: string): DocumentType;
     createHTMLDocument(title: string): Document;
     hasFeature(feature: string | null, version: string | null): boolean;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -991,5 +991,11 @@
         "interface": "DOMImplementation",
         "name": "hasFeature",
         "signatures": ["hasFeature(feature: string | null, version: string | null): boolean"]
+    },
+    {
+        "kind": "method",
+        "interface": "DOMImplementation",
+        "name": "createDocument",
+        "signatures": ["createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document"]
     }
  ]


### PR DESCRIPTION
According to the [DOM Specification](https://www.w3.org/TR/DOM-Level-2-Core/core.html#ID-102161490) the `doctype` parameter can be null.

Fixes Microsoft/TypeScript#14229