### PR TITLE
Fix AudioNode.connect method

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1396,6 +1396,7 @@ interface AudioNode extends EventTarget {
     readonly numberOfInputs: number;
     readonly numberOfOutputs: number;
     connect(destination: AudioNode, output?: number, input?: number): AudioNode;
+    connect(destination: AudioParam, output?: number): void;
     disconnect(output?: number): void;
     disconnect(destination: AudioNode, output?: number, input?: number): void;
     disconnect(destination: AudioParam, output?: number): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -488,6 +488,15 @@
     {
         "kind": "method",
         "interface": "AudioNode",
+        "name": "connect",
+        "signatures": [
+            "connect(destination: AudioNode, output?: number, input?: number): AudioNode",
+            "connect(destination: AudioParam, output?: number): void"
+        ]
+    },
+    {
+        "kind": "method",
+        "interface": "AudioNode",
         "name": "disconnect",
         "signatures": [
              "disconnect(output?: number): void",


### PR DESCRIPTION
See [spec](https://webaudio.github.io/web-audio-api/#widl-AudioNode-connect-void-AudioParam-destination-unsigned-long-output)

Fixes Microsoft/TypeScript#14355