### PR TITLE
Added ImageBitmap interface

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13261,6 +13261,8 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     webkitConvertPointFromNodeToPage(node: Node, pt: WebKitPoint): WebKitPoint;
     webkitConvertPointFromPageToNode(node: Node, pt: WebKitPoint): WebKitPoint;
     webkitRequestAnimationFrame(callback: FrameRequestCallback): number;
+    createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     scroll(options?: ScrollToOptions): void;
     scrollTo(options?: ScrollToOptions): void;
     scrollBy(options?: ScrollToOptions): void;
@@ -13834,6 +13836,21 @@ interface Canvas2DContextAttributes {
     willReadFrequently?: boolean;
     storage?: boolean;
     [attribute: string]: boolean | string | undefined;
+}
+
+interface ImageBitmapOptions {
+    imageOrientation?: ImageOrientation;
+    premultiplyAlpha?: PremultiplyAlpha;
+    colorSpaceConversion?: ColorSpaceConversion;
+    resizeWidth?: number;
+    resizeHeight?: number;
+    resizeQuality?: ResizeQuality;
+}
+
+interface ImageBitmap {
+    readonly width: number;
+    readonly height: number;
+    close(): void;
 }
 
 interface URLSearchParams {
@@ -14841,6 +14858,8 @@ declare function webkitCancelAnimationFrame(handle: number): void;
 declare function webkitConvertPointFromNodeToPage(node: Node, pt: WebKitPoint): WebKitPoint;
 declare function webkitConvertPointFromPageToNode(node: Node, pt: WebKitPoint): WebKitPoint;
 declare function webkitRequestAnimationFrame(callback: FrameRequestCallback): number;
+declare function createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
 declare function scroll(options?: ScrollToOptions): void;
 declare function scrollTo(options?: ScrollToOptions): void;
 declare function scrollBy(options?: ScrollToOptions): void;
@@ -14910,6 +14929,13 @@ type RTCTransport = RTCDtlsTransport | RTCSrtpSdesTransport;
 type RequestInfo = Request | string;
 type USVString = string;
 type payloadtype = number;
+type HTMLOrSVGImageElement = HTMLImageElement | SVGImageElement;
+type CanvasImageSource = HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap;
+type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
+type ImageOrientation = "none" | "flipY";
+type PremultiplyAlpha = "none" | "premultiply" | "default";
+type ColorSpaceConversion = "none" | "default";
+type ResizeQuality = "pixelated" | "low" | "medium" | "high";
 type ScrollBehavior = "auto" | "instant" | "smooth";
 type ScrollLogicalPosition = "start" | "center" | "end" | "nearest";
 type IDBValidKey = number | string | Date | IDBArrayKey;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13261,8 +13261,8 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     webkitConvertPointFromNodeToPage(node: Node, pt: WebKitPoint): WebKitPoint;
     webkitConvertPointFromPageToNode(node: Node, pt: WebKitPoint): WebKitPoint;
     webkitRequestAnimationFrame(callback: FrameRequestCallback): number;
-    createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
-    createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     scroll(options?: ScrollToOptions): void;
     scrollTo(options?: ScrollToOptions): void;
     scrollBy(options?: ScrollToOptions): void;
@@ -13839,12 +13839,12 @@ interface Canvas2DContextAttributes {
 }
 
 interface ImageBitmapOptions {
-    imageOrientation?: ImageOrientation;
-    premultiplyAlpha?: PremultiplyAlpha;
-    colorSpaceConversion?: ColorSpaceConversion;
+    imageOrientation?: "none" | "flipY";
+    premultiplyAlpha?: "none" | "premultiply" | "default";
+    colorSpaceConversion?: "none" | "default";
     resizeWidth?: number;
     resizeHeight?: number;
-    resizeQuality?: ResizeQuality;
+    resizeQuality?: "pixelated" | "low" | "medium" | "high";
 }
 
 interface ImageBitmap {
@@ -14858,8 +14858,8 @@ declare function webkitCancelAnimationFrame(handle: number): void;
 declare function webkitConvertPointFromNodeToPage(node: Node, pt: WebKitPoint): WebKitPoint;
 declare function webkitConvertPointFromPageToNode(node: Node, pt: WebKitPoint): WebKitPoint;
 declare function webkitRequestAnimationFrame(callback: FrameRequestCallback): number;
-declare function createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
-declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
 declare function scroll(options?: ScrollToOptions): void;
 declare function scrollTo(options?: ScrollToOptions): void;
 declare function scrollBy(options?: ScrollToOptions): void;
@@ -14929,13 +14929,6 @@ type RTCTransport = RTCDtlsTransport | RTCSrtpSdesTransport;
 type RequestInfo = Request | string;
 type USVString = string;
 type payloadtype = number;
-type HTMLOrSVGImageElement = HTMLImageElement | SVGImageElement;
-type CanvasImageSource = HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap;
-type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
-type ImageOrientation = "none" | "flipY";
-type PremultiplyAlpha = "none" | "premultiply" | "default";
-type ColorSpaceConversion = "none" | "default";
-type ResizeQuality = "pixelated" | "low" | "medium" | "high";
 type ScrollBehavior = "auto" | "instant" | "smooth";
 type ScrollLogicalPosition = "start" | "center" | "end" | "nearest";
 type IDBValidKey = number | string | Date | IDBArrayKey;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1407,8 +1407,8 @@ interface WorkerGlobalScope extends EventTarget, WorkerUtils, WindowConsole, Glo
     readonly performance: Performance;
     readonly self: WorkerGlobalScope;
     msWriteProfilerMark(profilerMarkName: string): void;
-    createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
-    createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
@@ -1470,12 +1470,12 @@ interface ErrorEventInit {
 }
 
 interface ImageBitmapOptions {
-    imageOrientation?: ImageOrientation;
-    premultiplyAlpha?: PremultiplyAlpha;
-    colorSpaceConversion?: ColorSpaceConversion;
+    imageOrientation?: "none" | "flipY";
+    premultiplyAlpha?: "none" | "premultiply" | "default";
+    colorSpaceConversion?: "none" | "default";
     resizeWidth?: number;
     resizeHeight?: number;
-    resizeQuality?: ResizeQuality;
+    resizeQuality?: "pixelated" | "low" | "medium" | "high";
 }
 
 interface ImageBitmap {
@@ -1714,8 +1714,8 @@ declare var onerror: (this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any;
 declare var performance: Performance;
 declare var self: WorkerGlobalScope;
 declare function msWriteProfilerMark(profilerMarkName: string): void;
-declare function createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
-declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
 declare function dispatchEvent(evt: Event): boolean;
 declare function removeEventListener(type: string, listener?: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 declare var indexedDB: IDBFactory;
@@ -1744,12 +1744,5 @@ type BodyInit = any;
 type IDBKeyPath = string;
 type RequestInfo = Request | string;
 type USVString = string;
-type HTMLOrSVGImageElement = HTMLImageElement | SVGImageElement;
-type CanvasImageSource = HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap;
-type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
-type ImageOrientation = "none" | "flipY";
-type PremultiplyAlpha = "none" | "premultiply" | "default";
-type ColorSpaceConversion = "none" | "default";
-type ResizeQuality = "pixelated" | "low" | "medium" | "high";
 type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1407,6 +1407,8 @@ interface WorkerGlobalScope extends EventTarget, WorkerUtils, WindowConsole, Glo
     readonly performance: Performance;
     readonly self: WorkerGlobalScope;
     msWriteProfilerMark(profilerMarkName: string): void;
+    createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+    createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     addEventListener<K extends keyof WorkerGlobalScopeEventMap>(type: K, listener: (this: WorkerGlobalScope, ev: WorkerGlobalScopeEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
@@ -1465,6 +1467,21 @@ interface ErrorEventInit {
     lineno?: number;
     conlno?: number;
     error?: any;
+}
+
+interface ImageBitmapOptions {
+    imageOrientation?: ImageOrientation;
+    premultiplyAlpha?: PremultiplyAlpha;
+    colorSpaceConversion?: ColorSpaceConversion;
+    resizeWidth?: number;
+    resizeHeight?: number;
+    resizeQuality?: ResizeQuality;
+}
+
+interface ImageBitmap {
+    readonly width: number;
+    readonly height: number;
+    close(): void;
 }
 
 interface BlobPropertyBag {
@@ -1697,6 +1714,8 @@ declare var onerror: (this: DedicatedWorkerGlobalScope, ev: ErrorEvent) => any;
 declare var performance: Performance;
 declare var self: WorkerGlobalScope;
 declare function msWriteProfilerMark(profilerMarkName: string): void;
+declare function createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>;
+declare function createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
 declare function dispatchEvent(evt: Event): boolean;
 declare function removeEventListener(type: string, listener?: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 declare var indexedDB: IDBFactory;
@@ -1725,5 +1744,12 @@ type BodyInit = any;
 type IDBKeyPath = string;
 type RequestInfo = Request | string;
 type USVString = string;
+type HTMLOrSVGImageElement = HTMLImageElement | SVGImageElement;
+type CanvasImageSource = HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap;
+type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
+type ImageOrientation = "none" | "flipY";
+type PremultiplyAlpha = "none" | "premultiply" | "default";
+type ColorSpaceConversion = "none" | "default";
+type ResizeQuality = "pixelated" | "low" | "medium" | "high";
 type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -89,63 +89,21 @@
         ]
     },
     {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "HTMLOrSVGImageElement",
-        "type": "HTMLImageElement | SVGImageElement"
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "CanvasImageSource",
-        "type": "HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap"
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "ImageBitmapSource",
-        "type": "CanvasImageSource | Blob | ImageData"
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "ImageOrientation",
-        "type": "\"none\" | \"flipY\""
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "PremultiplyAlpha",
-        "type": "\"none\" | \"premultiply\" | \"default\""
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "ColorSpaceConversion",
-        "type": "\"none\" | \"default\""
-    },
-    {
-        "kind": "typedef",
-        "flavor": "Worker",
-        "name": "ResizeQuality",
-        "type": "\"pixelated\" | \"low\" | \"medium\" | \"high\""
-    },
-    {
         "kind": "interface",
         "flavor": "Worker",
         "name": "ImageBitmapOptions",
         "properties": [
             {
                 "name": "imageOrientation?",
-                "type": "ImageOrientation"
+                "type": "\"none\" | \"flipY\""
             },
             {
                 "name": "premultiplyAlpha?",
-                "type": "PremultiplyAlpha"
+                "type": "\"none\" | \"premultiply\" | \"default\""
             },
             {
                 "name": "colorSpaceConversion?",
-                "type": "ColorSpaceConversion"
+                "type": "\"none\" | \"default\""
             },
             {
                 "name": "resizeWidth?",
@@ -157,7 +115,7 @@
             },
             {
                 "name": "resizeQuality?",
-                "type": "ResizeQuality"
+                "type": "\"pixelated\" | \"low\" | \"medium\" | \"high\""
             }
         ]
     },
@@ -189,8 +147,8 @@
         "interface": "Window",
         "name": "createImageBitmap",
         "signatures": [
-             "createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>",
-             "createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
+             "createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>",
+             "createImageBitmap(image: HTMLImageElement | SVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
         ]
     },
     {
@@ -198,8 +156,8 @@
         "interface": "WorkerGlobalScope",
         "name": "createImageBitmap",
         "signatures": [
-             "createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>",
-             "createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
+             "createImageBitmap(image: ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>",
+             "createImageBitmap(image: ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
         ]
     },
     {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -89,6 +89,120 @@
         ]
     },
     {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "HTMLOrSVGImageElement",
+        "type": "HTMLImageElement | SVGImageElement"
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "CanvasImageSource",
+        "type": "HTMLOrSVGImageElement | HTMLVideoElement | HTMLCanvasElement | ImageBitmap"
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "ImageBitmapSource",
+        "type": "CanvasImageSource | Blob | ImageData"
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "ImageOrientation",
+        "type": "\"none\" | \"flipY\""
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "PremultiplyAlpha",
+        "type": "\"none\" | \"premultiply\" | \"default\""
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "ColorSpaceConversion",
+        "type": "\"none\" | \"default\""
+    },
+    {
+        "kind": "typedef",
+        "flavor": "Worker",
+        "name": "ResizeQuality",
+        "type": "\"pixelated\" | \"low\" | \"medium\" | \"high\""
+    },
+    {
+        "kind": "interface",
+        "flavor": "Worker",
+        "name": "ImageBitmapOptions",
+        "properties": [
+            {
+                "name": "imageOrientation?",
+                "type": "ImageOrientation"
+            },
+            {
+                "name": "premultiplyAlpha?",
+                "type": "PremultiplyAlpha"
+            },
+            {
+                "name": "colorSpaceConversion?",
+                "type": "ColorSpaceConversion"
+            },
+            {
+                "name": "resizeWidth?",
+                "type": "number"
+            },
+            {
+                "name": "resizeHeight?",
+                "type": "number"
+            },
+            {
+                "name": "resizeQuality?",
+                "type": "ResizeQuality"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "ImageBitmap",
+        "flavor": "Worker",
+        "properties": [
+            {
+                "name": "width",
+                "readonly": true,
+                "type": "number"
+            },
+            {
+                "name": "height",
+                "readonly": true,
+                "type": "number"
+            }
+        ],
+        "methods": [
+            {
+                "name": "close",
+                "signatures": ["close(): void"]
+            }
+        ]
+    },
+    {
+        "kind": "method",
+        "interface": "Window",
+        "name": "createImageBitmap",
+        "signatures": [
+             "createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>",
+             "createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
+        ]
+    },
+    {
+        "kind": "method",
+        "interface": "WorkerGlobalScope",
+        "name": "createImageBitmap",
+        "signatures": [
+             "createImageBitmap(image: ImageBitmapSource, options?: ImageBitmapOptions): Promise<ImageBitmap>",
+             "createImageBitmap(image: ImageBitmapSource, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>"
+        ]
+    },
+    {
         "kind": "property",
         "interface": "IDBObjectStoreParameters",
         "name": "autoIncrement?",


### PR DESCRIPTION
Fixes [ImageBitmap interface missing #14402](https://github.com/Microsoft/TypeScript/issues/14402)

Adds interfaces `ImageBitmap`, `ImageBitmapOptions` and the associated typedefs to Window and Worker scope. See [WHATWG HTML Living Standard](https://html.spec.whatwg.org/multipage/webappapis.html#imagebitmap)

Wasn't sure about the "flavor" tag. `Worker` seems to be the one I need here. but is there a description of `All`, `Web`, `DOM` and maybe others?