### PR TITLE
Add missing methods for FormData type

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3796,12 +3796,12 @@ declare var FocusNavigationEvent: {
 }
 
 interface FormData {
-    append(name: string, value: string | blob, fileName?: string): void;
+    append(name: string, value: string | Blob, fileName?: string): void;
     delete(name: string): void;
     get(name: string): FormDataEntryValue | null;
     getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
-    set(name: string, value: string | blob, fileName?: string): void;
+    set(name: string, value: string | Blob, fileName?: string): void;
 }
 
 declare var FormData: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3796,12 +3796,12 @@ declare var FocusNavigationEvent: {
 }
 
 interface FormData {
-    append(name: any, value: any, fileName?: string): void;
-    delete(name: any): void;
-    get(name: any): any;
-    getAll(name: any): any;
-    has(name: any): any;
-    set(name: any, value: any, fileName?: string): void;
+    append(name: string, value: any, fileName?: string): void;
+    delete(name: string): void;
+    get(name: string): any;
+    getAll(name: string): any[];
+    has(name: string): boolean;
+    set(name: string, value: any, fileName?: string): void;
 }
 
 declare var FormData: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3796,7 +3796,12 @@ declare var FocusNavigationEvent: {
 }
 
 interface FormData {
-    append(name: any, value: any, blobName?: string): void;
+    append(name: any, value: any, fileName?: string): void;
+    delete(name: any): void;
+    get(name: any): any;
+    getAll(name: any): any;
+    has(name: any): any;
+    set(name: any, value: any, fileName?: string): void;
 }
 
 declare var FormData: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3796,12 +3796,12 @@ declare var FocusNavigationEvent: {
 }
 
 interface FormData {
-    append(name: string, value: any, fileName?: string): void;
+    append(name: string, value: string | blob, fileName?: string): void;
     delete(name: string): void;
-    get(name: string): any;
-    getAll(name: string): any[];
+    get(name: string): FormDataEntryValue | null;
+    getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
-    set(name: string, value: any, fileName?: string): void;
+    set(name: string, value: string | blob, fileName?: string): void;
 }
 
 declare var FormData: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14946,3 +14946,4 @@ type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;
 type MouseWheelEvent = WheelEvent;
 type ScrollRestoration = "auto" | "manual";
+type FormDataEntryValue = string | File;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1746,3 +1746,4 @@ type RequestInfo = Request | string;
 type USVString = string;
 type IDBValidKey = number | string | Date | IDBArrayKey;
 type BufferSource = ArrayBuffer | ArrayBufferView;
+type FormDataEntryValue = string | File;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1536,6 +1536,11 @@
         "signatures": ["getElementById(elementId: string): HTMLElement | null"]
     },
     {
+        "kind": "typedef",
+        "name": "FormDataEntryValue",
+        "type": "string | File"
+    },
+    {
         "kind": "method",
         "interface": "FormData",
         "name": "delete",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1534,5 +1534,40 @@
         "name": "getElementById",
         "flavor": "DOM",
         "signatures": ["getElementById(elementId: string): HTMLElement | null"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "delete",
+        "flavor": "Web",
+        "signatures": ["delete(name: any): void"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "get",
+        "flavor": "Web",
+        "signatures": ["get(name: any): any"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "getAll",
+        "flavor": "Web",
+        "signatures": ["getAll(name: any): any"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "has",
+        "flavor": "Web",
+        "signatures": ["has(name: any): any"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "set",
+        "flavor": "Web",
+        "signatures": ["set(name: any, value: any, fileName?: string): void"]
     }
 ]

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1547,14 +1547,14 @@
         "interface": "FormData",
         "name": "get",
         "flavor": "Web",
-        "signatures": ["get(name: string): any"]
+        "signatures": ["get(name: string): FormDataEntryValue | null"]
     },
     {
         "kind": "method",
         "interface": "FormData",
         "name": "getAll",
         "flavor": "Web",
-        "signatures": ["getAll(name: string): any[]"]
+        "signatures": ["getAll(name: string): FormDataEntryValue[]"]
     },
     {
         "kind": "method",
@@ -1568,6 +1568,6 @@
         "interface": "FormData",
         "name": "set",
         "flavor": "Web",
-        "signatures": ["set(name: string, value: any, fileName?: string): void"]
+        "signatures": ["set(name: string, value: string | blob, fileName?: string): void"]
     }
 ]

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1573,6 +1573,6 @@
         "interface": "FormData",
         "name": "set",
         "flavor": "Web",
-        "signatures": ["set(name: string, value: string | blob, fileName?: string): void"]
+        "signatures": ["set(name: string, value: string | Blob, fileName?: string): void"]
     }
 ]

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1540,34 +1540,34 @@
         "interface": "FormData",
         "name": "delete",
         "flavor": "Web",
-        "signatures": ["delete(name: any): void"]
+        "signatures": ["delete(name: string): void"]
     },
     {
         "kind": "method",
         "interface": "FormData",
         "name": "get",
         "flavor": "Web",
-        "signatures": ["get(name: any): any"]
+        "signatures": ["get(name: string): any"]
     },
     {
         "kind": "method",
         "interface": "FormData",
         "name": "getAll",
         "flavor": "Web",
-        "signatures": ["getAll(name: any): any"]
+        "signatures": ["getAll(name: string): any[]"]
     },
     {
         "kind": "method",
         "interface": "FormData",
         "name": "has",
         "flavor": "Web",
-        "signatures": ["has(name: any): any"]
+        "signatures": ["has(name: string): boolean"]
     },
     {
         "kind": "method",
         "interface": "FormData",
         "name": "set",
         "flavor": "Web",
-        "signatures": ["set(name: any, value: any, fileName?: string): void"]
+        "signatures": ["set(name: string, value: any, fileName?: string): void"]
     }
 ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1022,6 +1022,6 @@
         "interface": "FormData",
         "name": "append",
         "flavor": "Web",
-        "signatures": ["append(name: string, value: any, fileName?: string): void"]
+        "signatures": ["append(name: string, value: string | blob, fileName?: string): void"]
     }
  ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1022,6 +1022,6 @@
         "interface": "FormData",
         "name": "append",
         "flavor": "Web",
-        "signatures": ["append(name: any, value: any, fileName?: string): void"]
+        "signatures": ["append(name: string, value: any, fileName?: string): void"]
     }
  ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1016,5 +1016,12 @@
         "interface": "DOMImplementation",
         "name": "createDocument",
         "signatures": ["createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document"]
+    },
+    {
+        "kind": "method",
+        "interface": "FormData",
+        "name": "append",
+        "flavor": "Web",
+        "signatures": ["append(name: any, value: any, fileName?: string): void"]
     }
  ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1022,6 +1022,6 @@
         "interface": "FormData",
         "name": "append",
         "flavor": "Web",
-        "signatures": ["append(name: string, value: string | blob, fileName?: string): void"]
+        "signatures": ["append(name: string, value: string | Blob, fileName?: string): void"]
     }
  ]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/14813 by updating the existing append method to better match the [Web APIs](https://developer.mozilla.org/en-US/docs/Web/API/FormData/FormData) and adding missing methods. Please let me know if there is anything I should add or change, thanks!