### PR TITLE
add URL typing to webworker

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13859,25 +13859,6 @@ interface ImageBitmap {
     close(): void;
 }
 
-interface URL {
-    href: string;
-    readonly origin: string;
-    protocol: string;
-    username: string;
-    password: string;
-    host: string;
-    hostname: string;
-    port: string;
-    pathname: string;
-    search: string;
-    toJSON(): string;
-}
-
-declare var URL: {
-    prototype: URL;
-    new (url: string, base?: string): URL;
-}
-
 interface URLSearchParams {
     /**
       * Appends a specified key/value pair as a new search parameter.

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13232,6 +13232,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     readonly top: Window;
     readonly window: Window;
     URL: typeof URL;
+    URLSearchParams: typeof URLSearchParams;
     Blob: typeof Blob;
     customElements: CustomElementRegistry;
     alert(message?: any): void;
@@ -13856,6 +13857,25 @@ interface ImageBitmap {
     readonly width: number;
     readonly height: number;
     close(): void;
+}
+
+interface URL {
+    href: string;
+    readonly origin: string;
+    protocol: string;
+    username: string;
+    password: string;
+    host: string;
+    hostname: string;
+    port: string;
+    pathname: string;
+    search: string;
+    toJSON(): string;
+}
+
+declare var URL: {
+    prototype: URL;
+    new (url: string, base?: string): URL;
 }
 
 interface URLSearchParams {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1406,6 +1406,8 @@ interface WorkerGlobalScope extends EventTarget, WorkerUtils, WindowConsole, Glo
     onerror: (this: WorkerGlobalScope, ev: ErrorEvent) => any;
     readonly performance: Performance;
     readonly self: WorkerGlobalScope;
+    URL: typeof URL;
+    URLSearchParams: typeof URLSearchParams;
     msWriteProfilerMark(profilerMarkName: string): void;
     createImageBitmap(image: ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     createImageBitmap(image: ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;
@@ -1482,6 +1484,25 @@ interface ImageBitmap {
     readonly width: number;
     readonly height: number;
     close(): void;
+}
+
+interface URL {
+    href: string;
+    readonly origin: string;
+    protocol: string;
+    username: string;
+    password: string;
+    host: string;
+    hostname: string;
+    port: string;
+    pathname: string;
+    search: string;
+    toJSON(): string;
+}
+
+declare var URL: {
+    prototype: URL;
+    new (url: string, base?: string): URL;
 }
 
 interface BlobPropertyBag {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1429,8 +1429,6 @@ interface WorkerGlobalScope extends EventTarget, WorkerUtils, WindowConsole, Glo
     onerror: (this: WorkerGlobalScope, ev: ErrorEvent) => any;
     readonly performance: Performance;
     readonly self: WorkerGlobalScope;
-    URL: typeof URL;
-    URLSearchParams: typeof URLSearchParams;
     msWriteProfilerMark(profilerMarkName: string): void;
     createImageBitmap(image: ImageBitmap | ImageData | Blob, options?: ImageBitmapOptions): Promise<ImageBitmap>;
     createImageBitmap(image: ImageBitmap | ImageData | Blob, sx: number, sy: number, sw: number, sh: number, options?: ImageBitmapOptions): Promise<ImageBitmap>;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -61,6 +61,10 @@ interface NotificationOptions {
     icon?: string;
 }
 
+interface ObjectURLOptions {
+    oneTimeOnly?: boolean;
+}
+
 interface PushSubscriptionOptionsInit {
     userVisibleOnly?: boolean;
     applicationServerKey?: any;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1008,6 +1008,29 @@ declare var SyncManager: {
     new(): SyncManager;
 }
 
+interface URL {
+    hash: string;
+    host: string;
+    hostname: string;
+    href: string;
+    readonly origin: string;
+    password: string;
+    pathname: string;
+    port: string;
+    protocol: string;
+    search: string;
+    username: string;
+    readonly searchParams: URLSearchParams;
+    toString(): string;
+}
+
+declare var URL: {
+    prototype: URL;
+    new(url: string, base?: string): URL;
+    createObjectURL(object: any, options?: ObjectURLOptions): string;
+    revokeObjectURL(url: string): void;
+}
+
 interface WebSocketEventMap {
     "close": CloseEvent;
     "error": Event;
@@ -1486,23 +1509,39 @@ interface ImageBitmap {
     close(): void;
 }
 
-interface URL {
-    href: string;
-    readonly origin: string;
-    protocol: string;
-    username: string;
-    password: string;
-    host: string;
-    hostname: string;
-    port: string;
-    pathname: string;
-    search: string;
-    toJSON(): string;
+interface URLSearchParams {
+    /**
+      * Appends a specified key/value pair as a new search parameter.
+      */
+    append(name: string, value: string): void;
+    /**
+      * Deletes the given search parameter, and its associated value, from the list of all search parameters.
+      */
+    delete(name: string): void;
+    /**
+      * Returns the first value associated to the given search parameter.
+      */
+    get(name: string): string | null;
+    /**
+      * Returns all the values association with a given search parameter.
+      */
+    getAll(name: string): string[];
+    /**
+      * Returns a Boolean indicating if such a search parameter exists.
+      */
+    has(name: string): boolean;
+    /**
+      * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
+      */
+    set(name: string, value: string): void;
 }
 
-declare var URL: {
-    prototype: URL;
-    new (url: string, base?: string): URL;
+declare var URLSearchParams: {
+    prototype: URLSearchParams;
+    /**
+      * Constructor returning a URLSearchParams object.
+      */
+    new (init?: string | URLSearchParams): URLSearchParams;
 }
 
 interface BlobPropertyBag {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -180,65 +180,7 @@
     },
     {
         "kind": "interface",
-        "name": "URL",
-        "flavor": "Worker",
-        "constructorSignatures": [
-            "new (url: string, base?: string): URL"
-        ],
-        "properties": [
-          {
-              "name": "href",
-              "type": "string"
-          },
-          {
-              "name": "origin",
-              "type": "string",
-              "readonly": true
-          },
-          {
-              "name": "protocol",
-              "type": "string"
-          },
-          {
-              "name": "username",
-              "type": "string"
-          },
-          {
-              "name": "password",
-              "type": "string"
-          },
-          {
-              "name": "host",
-              "type": "string"
-          },
-          {
-              "name": "hostname",
-              "type": "string"
-          },
-          {
-              "name": "port",
-              "type": "string"
-          },
-          {
-              "name": "pathname",
-              "type": "string"
-          },
-          {
-              "name": "search",
-              "type": "string"
-          }
-        ],
-        "methods": [
-            {
-                "name": "toJSON",
-                "signatures": ["toJSON(): string"]
-            }
-        ]
-    },
-    {
-        "kind": "interface",
         "name": "URLSearchParams",
-        "flavor": "All",
         "constructorSignatures": [
             "new (init?: string | URLSearchParams): URLSearchParams"
         ],

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -227,21 +227,7 @@
     },
     {
         "kind": "property",
-        "interface": "WorkerGlobalScope",
-        "exposeGlobally": false,
-        "name": "URL",
-        "type": "typeof URL"
-    },
-    {
-        "kind": "property",
         "interface": "Window",
-        "exposeGlobally": false,
-        "name": "URLSearchParams",
-        "type": "typeof URLSearchParams"
-    },
-    {
-        "kind": "property",
-        "interface": "WorkerGlobalScope",
         "exposeGlobally": false,
         "name": "URLSearchParams",
         "type": "typeof URLSearchParams"

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -180,8 +180,65 @@
     },
     {
         "kind": "interface",
+        "name": "URL",
+        "flavor": "Worker",
+        "constructorSignatures": [
+            "new (url: string, base?: string): URL"
+        ],
+        "properties": [
+          {
+              "name": "href",
+              "type": "string"
+          },
+          {
+              "name": "origin",
+              "type": "string",
+              "readonly": true
+          },
+          {
+              "name": "protocol",
+              "type": "string"
+          },
+          {
+              "name": "username",
+              "type": "string"
+          },
+          {
+              "name": "password",
+              "type": "string"
+          },
+          {
+              "name": "host",
+              "type": "string"
+          },
+          {
+              "name": "hostname",
+              "type": "string"
+          },
+          {
+              "name": "port",
+              "type": "string"
+          },
+          {
+              "name": "pathname",
+              "type": "string"
+          },
+          {
+              "name": "search",
+              "type": "string"
+          }
+        ],
+        "methods": [
+            {
+                "name": "toJSON",
+                "signatures": ["toJSON(): string"]
+            }
+        ]
+    },
+    {
+        "kind": "interface",
         "name": "URLSearchParams",
-        "flavor": "Web",
+        "flavor": "All",
         "constructorSignatures": [
             "new (init?: string | URLSearchParams): URLSearchParams"
         ],
@@ -225,6 +282,27 @@
         "exposeGlobally": false,
         "name": "URL",
         "type": "typeof URL"
+    },
+    {
+        "kind": "property",
+        "interface": "WorkerGlobalScope",
+        "exposeGlobally": false,
+        "name": "URL",
+        "type": "typeof URL"
+    },
+    {
+        "kind": "property",
+        "interface": "Window",
+        "exposeGlobally": false,
+        "name": "URLSearchParams",
+        "type": "typeof URLSearchParams"
+    },
+    {
+        "kind": "property",
+        "interface": "WorkerGlobalScope",
+        "exposeGlobally": false,
+        "name": "URLSearchParams",
+        "type": "typeof URLSearchParams"
     },
     {
         "kind": "property",

--- a/inputfiles/knownWorkerInterfaces.json
+++ b/inputfiles/knownWorkerInterfaces.json
@@ -91,6 +91,8 @@
     "SyncEventInit",
     "SyncManager",
     "USVString",
+    "URL",
+    "URLSearchParams",
     "WebSocket",
     "WindowBase64",
     "WindowConsole",

--- a/inputfiles/knownWorkerInterfaces.json
+++ b/inputfiles/knownWorkerInterfaces.json
@@ -66,6 +66,7 @@
     "NotificationEventInit",
     "NotificationOptions",
     "NotificationPermissionCallback",
+    "ObjectURLOptions",
     "Performance",
     "PerformanceNavigation",
     "PerformanceTiming",


### PR DESCRIPTION
`URL` is also available in worker. ([URL IDL spec](https://url.spec.whatwg.org/#idl-index)). Fix https://github.com/Microsoft/TypeScript/issues/14878.

---

**Questions**:

1. `URL` tying is already defined in [`inputfiles/browser.webidl.xml#L11367-L11395`](https://github.com/Microsoft/TSJS-lib-generator/blob/master/inputfiles/browser.webidl.xml#L11367-L11395), so it is only need to added to `worker`. So I added `"flavor": "Worker"`, but it seems doesn't work.(same as `"flavor": "All"` for `URLSearchParams`) 😅
2. I'm not sure whether the `URL` and `URLSearchParams` should be added to `WorkerGlobalScope`.  It is signed as `Exposed=(Window,Worker)` in the [spec IDL](https://url.spec.whatwg.org/#idl-index)
3. The spec IDL use `USVString`, but I use `string` here (keep it same as previous added `URLSearchParams` typing). Doesn't it matters?

**Updates**:

1. Just add `URL` and `URLSearcParams` to `knownWorkerInterfaces.json`.
2. `URL` and `URLSearchParams` shouldn't be added to `WorkerGlobalScope`.(The same as [fetch related typing](https://fetch.spec.whatwg.org/#request-class))