### PR TITLE
add FormData typing to webworker

### DIFF
--- a/TS.fsx
+++ b/TS.fsx
@@ -699,7 +699,7 @@ module Emit =
     let extendedTypes =
         ["ArrayBuffer";"ArrayBufferView";"Int8Array";"Uint8Array";"Int16Array";"Uint16Array";"Int32Array";"Uint32Array";"Float32Array";"Float64Array"]
 
-    let integerTypes = 
+    let integerTypes =
         ["byte";"octet";"short";"unsigned short";"long";"unsigned long";"long long";"unsigned long long"]
 
     /// Get typescript type using object dom type, object name, and it's associated interface name
@@ -731,7 +731,7 @@ module Emit =
                 // Name of an interface / enum / dict. Just return itself
                 if allInterfacesMap.ContainsKey objDomType ||
                     allCallbackFuncs.ContainsKey objDomType ||
-                    allDictionariesMap.ContainsKey objDomType || 
+                    allDictionariesMap.ContainsKey objDomType ||
                     allEnumsMap.ContainsKey objDomType then
                     objDomType
                 // Name of a type alias. Just return itself
@@ -1086,13 +1086,13 @@ module Emit =
                 "%saddEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;"
                 fPrefix
 
-    let EmitConstructorSignature (i:Browser.Interface) =
+    let EmitConstructorSignature flavor (i:Browser.Interface) =
         let emitConstructorSigFromJson (c: InputJsonType.Root) =
             c.Signatures |> Array.iter (Pt.Printl "%s;")
 
-        let removedCtor = getRemovedItems ItemKind.Constructor Flavor.All  |> Array.tryFind (matchInterface i.Name)
+        let removedCtor = getRemovedItems ItemKind.Constructor flavor  |> Array.tryFind (matchInterface i.Name)
         if Option.isNone removedCtor then
-            let overriddenCtor = getOverriddenItems ItemKind.Constructor Flavor.All  |> Array.tryFind (matchInterface i.Name)
+            let overriddenCtor = getOverriddenItems ItemKind.Constructor flavor  |> Array.tryFind (matchInterface i.Name)
             match overriddenCtor with
             | Some c' -> emitConstructorSigFromJson c'
             | _ ->
@@ -1104,7 +1104,7 @@ module Emit =
                         Pt.Printl "new(%s): %s;" paramsString i.Name
                 | _ -> Pt.Printl "new(): %s;" i.Name
 
-        getAddedItems ItemKind.Constructor Flavor.All
+        getAddedItems ItemKind.Constructor flavor
         |> Array.filter (matchInterface i.Name)
         |> Array.iter emitConstructorSigFromJson
 
@@ -1113,7 +1113,7 @@ module Emit =
         Pt.IncreaseIndent()
 
         Pt.Printl "prototype: %s;" i.Name
-        EmitConstructorSignature i
+        EmitConstructorSignature flavor i
         EmitConstants i
         let prefix = ""
         EmitMembers flavor prefix EmitScope.StaticOnly i
@@ -1507,11 +1507,11 @@ module Emit =
             List.contains p.Type integerTypes
 
         // check anonymous unsigned long getter and length property
-        let isIterableGetter (m: Browser.Method) = 
+        let isIterableGetter (m: Browser.Method) =
             m.Getter = Some 1 && m.Params.Length = 1 && isIntegerKeyParam m.Params.[0]
 
         let findIterableGetter() =
-            let anonymousGetter = 
+            let anonymousGetter =
                 if (i.AnonymousMethods.IsSome) then Array.tryFind isIterableGetter i.AnonymousMethods.Value.Methods
                 else None
 
@@ -1541,7 +1541,7 @@ module Emit =
         Pt.Printl ""
 
         browser.Interfaces |> Array.iter EmitIterator
-        
+
         fprintf target "%s" (Pt.GetResult())
         target.Flush()
         target.Close()

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -450,6 +450,15 @@ declare var FileReader: {
     new(): FileReader;
 };
 
+interface FormData {
+    append(name: string, value: string | Blob, fileName?: string): void;
+}
+
+declare var FormData: {
+    prototype: FormData;
+    new (form?: HTMLFormElement): FormData;
+}
+
 interface Headers {
     append(name: string, value: string): void;
     delete(name: string): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -456,8 +456,8 @@ interface FormData {
 
 declare var FormData: {
     prototype: FormData;
-    new (form?: HTMLFormElement): FormData;
-}
+    new(): FormData;
+};
 
 interface Headers {
     append(name: string, value: string): void;

--- a/inputfiles/knownWorkerInterfaces.json
+++ b/inputfiles/knownWorkerInterfaces.json
@@ -33,6 +33,7 @@
     "FileList",
     "FileReader",
     "ForEachCallback",
+    "FormData",
     "FunctionStringCallback",
     "GetNotificationOptions",
     "GlobalFetch",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -359,6 +359,7 @@
     {
         "kind": "constructor",
         "interface": "FormData",
+        "flavor": "Web",
         "signatures": ["new (form?: HTMLFormElement): FormData"]
     },
     {


### PR DESCRIPTION
`FormData` is also available in worker. ([IDL spec](https://xhr.spec.whatwg.org/#interface-formdata)). 

### Problem

The `FormData` declaration in DOM is

```ts
declare var FormData: {
    prototype: FormData;
    new (form?: HTMLFormElement): FormData;
}
```

But `HTMLFormElement` is not available in worker. So I think we should change the constructor to:
 (but can't find related info in [w3c spec](https://xhr.spec.whatwg.org/#interface-formdata))

```ts
new (): FormData;
```

![form-data](https://cloud.githubusercontent.com/assets/6076919/25038790/0f024a6c-2133-11e7-9d25-e397573cbb1a.png)

I add a `flavor` to `inputfiles/overridingTypes.json`, but it seems not work. How can I achieve this？