### PR TITLE
Add BroadcastChannel API

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13828,6 +13828,26 @@ interface XMLHttpRequestEventTarget {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }
 
+interface BroadcastChannel extends EventTarget {
+    readonly name: string;
+    onmessage: (ev: MessageEvent) => any;
+    onmessageerror: (ev: MessageEvent) => any;
+    close(): void;
+    postMessage(message: any): void;
+    addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, useCapture?: boolean): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+}
+
+declare var BroadcastChannel: {
+    prototype: BroadcastChannel;
+    new(name: string): BroadcastChannel;
+};
+
+interface BroadcastChannelEventMap {
+    message: MessageEvent;
+    messageerror: MessageEvent;
+}
+
 interface ErrorEventInit {
     message?: string;
     filename?: string;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1490,6 +1490,26 @@ interface WorkerUtils extends Object, WindowBase64 {
     setTimeout(handler: any, timeout?: any, ...args: any[]): number;
 }
 
+interface BroadcastChannel extends EventTarget {
+    readonly name: string;
+    onmessage: (ev: MessageEvent) => any;
+    onmessageerror: (ev: MessageEvent) => any;
+    close(): void;
+    postMessage(message: any): void;
+    addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, useCapture?: boolean): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
+}
+
+declare var BroadcastChannel: {
+    prototype: BroadcastChannel;
+    new(name: string): BroadcastChannel;
+};
+
+interface BroadcastChannelEventMap {
+    message: MessageEvent;
+    messageerror: MessageEvent;
+}
+
 interface ErrorEventInit {
     message?: string;
     filename?: string;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1,6 +1,58 @@
 [
     {
         "kind": "interface",
+        "name": "BroadcastChannel",
+        "extends": "EventTarget",
+        "constructorSignatures": ["new(name: string): BroadcastChannel"],
+        "properties": [
+            {
+                "readonly": true,
+                "name": "name",
+                "type": "string"
+            },
+            {
+                "name": "onmessage",
+                "type": "(ev: MessageEvent) => any"
+            },
+            {
+                "name": "onmessageerror",
+                "type": "(ev: MessageEvent) => any"
+            }
+        ],
+        "methods": [
+            {
+                "name": "close",
+                "signatures": ["close(): void"]
+            },
+            {
+                "name": "postMessage",
+                "signatures": ["postMessage(message: any): void"]
+            },
+            {
+                "name": "addEventListener",
+                "signatures": [
+		    "addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, useCapture?: boolean): void",
+		    "addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void"
+		]
+            }
+        ]
+    },
+    {
+        "kind": "interface",
+        "name": "BroadcastChannelEventMap",
+        "properties": [
+            {
+                "name": "message",
+                "type": "MessageEvent"
+            },
+            {
+                "name": "messageerror",
+                "type": "MessageEvent"
+            }
+        ]
+    },
+    {
+        "kind": "interface",
         "name": "ErrorEventInit",
         "properties": [
             {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/15407

I cannot add the following code. How can I do that?

```ts
declare var BroadcastChannel: {
    prototype: BroadcastChannel;
    new(name: string): BroadcastChannel;
}
```