### PR TITLE
Add an 'InsertPosition' string literal type, to be used by the element insertion methods (insertAdjacentElement / insertAdjacentHTML / insertAdjacentText)

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3641,9 +3641,9 @@ interface Element extends Node, GlobalEventHandlers, ElementTraversal, NodeSelec
     scrollTo(x: number, y: number): void;
     scrollBy(options?: ScrollToOptions): void;
     scrollBy(x: number, y: number): void;
-    insertAdjacentElement(position: string, insertedElement: Element): Element | null;
-    insertAdjacentHTML(where: string, html: string): void;
-    insertAdjacentText(where: string, text: string): void;
+    insertAdjacentElement(position: InsertPosition, insertedElement: Element): Element | null;
+    insertAdjacentHTML(where: InsertPosition, html: string): void;
+    insertAdjacentText(where: InsertPosition, text: string): void;
     attachShadow(shadowRootInitDict: ShadowRootInit): ShadowRoot;
     addEventListener<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14963,6 +14963,7 @@ type BufferSource = ArrayBuffer | ArrayBufferView;
 type MouseWheelEvent = WheelEvent;
 type ScrollRestoration = "auto" | "manual";
 type FormDataEntryValue = string | File;
+type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
 type AppendMode = "segments" | "sequence";
 type AudioContextState = "suspended" | "running" | "closed";
 type BiquadFilterType = "lowpass" | "highpass" | "bandpass" | "lowshelf" | "highshelf" | "peaking" | "notch" | "allpass";

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1219,19 +1219,19 @@
         "kind": "method",
         "interface": "Element",
         "name": "insertAdjacentElement",
-        "signatures": ["insertAdjacentElement(position: string, insertedElement: Element): Element | null"]
+        "signatures": ["insertAdjacentElement(position: InsertPosition, insertedElement: Element): Element | null"]
     },
     {
         "kind": "method",
         "interface": "Element",
         "name": "insertAdjacentHTML",
-        "signatures": ["insertAdjacentHTML(where: string, html: string): void"]
+        "signatures": ["insertAdjacentHTML(where: InsertPosition, html: string): void"]
     },
     {
         "kind": "method",
         "interface": "Element",
         "name": "insertAdjacentText",
-        "signatures": ["insertAdjacentText(where: string, text: string): void"]
+        "signatures": ["insertAdjacentText(where: InsertPosition, text: string): void"]
     },
     {
         "kind": "property",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1616,5 +1616,11 @@
             "name": "changedTouches?",
             "type": "Touch[]"
         }]
+    },
+    {
+        "kind": "typedef",
+        "name": "InsertPosition",
+        "flavor": "Web",
+        "type": "\"beforebegin\" | \"afterbegin\" | \"beforeend\" | \"afterend\""
     }
 ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1075,12 +1075,6 @@
         ]
     },
     {
-        "kind": "typedef",
-        "name": "InsertPosition",
-        "flavor": "Web",
-        "type": "\"beforebegin\" | \"afterbegin\" | \"beforeend\" | \"afterend\""
-    },
-    {
         "kind": "method",
         "interface": "Element",
         "name": "insertAdjacentElement",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1073,5 +1073,29 @@
         "signatures": [
             "new(data?: string): Text"
         ]
+    },
+    {
+        "kind": "typedef",
+        "name": "InsertPosition",
+        "flavor": "Web",
+        "type": "\"beforebegin\" | \"afterbegin\" | \"beforeend\" | \"afterend\""
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentElement",
+        "signatures": ["insertAdjacentElement(position: InsertPosition, insertedElement: Element): Element | null"]
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentHTML",
+        "signatures": ["insertAdjacentHTML(where: InsertPosition, html: string): void"]
+    },
+    {
+        "kind": "method",
+        "interface": "Element",
+        "name": "insertAdjacentText",
+        "signatures": ["insertAdjacentText(where: InsertPosition, text: string): void"]
     }
  ]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1073,23 +1073,5 @@
         "signatures": [
             "new(data?: string): Text"
         ]
-    },
-    {
-        "kind": "method",
-        "interface": "Element",
-        "name": "insertAdjacentElement",
-        "signatures": ["insertAdjacentElement(position: InsertPosition, insertedElement: Element): Element | null"]
-    },
-    {
-        "kind": "method",
-        "interface": "Element",
-        "name": "insertAdjacentHTML",
-        "signatures": ["insertAdjacentHTML(where: InsertPosition, html: string): void"]
-    },
-    {
-        "kind": "method",
-        "interface": "Element",
-        "name": "insertAdjacentText",
-        "signatures": ["insertAdjacentText(where: InsertPosition, text: string): void"]
     }
  ]


### PR DESCRIPTION
Here's the associated report: https://github.com/Microsoft/TypeScript/issues/15620