### PR TITLE
Fix Console types in browser.webidl.xml

### DIFF
--- a/inputfiles/browser.webidl.xml
+++ b/inputfiles/browser.webidl.xml
@@ -3086,9 +3086,11 @@
         </method>
         <method name="group" type="void">
           <param name="groupTitle" optional="1" type="DOMString" />
+          <param name="optionalParams" type="any" variadic="1" />
         </method>
         <method name="groupCollapsed" type="void">
           <param name="groupTitle" optional="1" type="DOMString" />
+          <param name="optionalParams" type="any" variadic="1" />
         </method>
         <method name="groupEnd" type="void" />
         <method name="info" type="void">


### PR DESCRIPTION
Add `optionalParams` to `group` and `groupCollapsed` methods of interface `Console`