### PR TITLE
Add `languages` property to `Navigator` interface

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8214,6 +8214,7 @@ interface Navigator extends Object, NavigatorID, NavigatorOnLine, NavigatorConte
     readonly cookieEnabled: boolean;
     gamepadInputEmulation: GamepadInputEmulationType;
     readonly language: string;
+    readonly languages: string[];
     readonly maxTouchPoints: number;
     readonly mimeTypes: MimeTypeArray;
     readonly msManipulationViewsEnabled: boolean;


### PR DESCRIPTION
`window.navigator.languages` is already supported on [some mainstream browsers](https://developer.mozilla.org/en/docs/Web/API/NavigatorLanguage/languages) and is **ESSENTIAL** for frontend to determine which interface language users prefer. For example, on Chrome, `navigator.languages[0]` indicates a more proper language option than `navigator.language`.
Please consider adding this property. Thank you!