### PR TITLE
Updated HTMLMediaElement.play return type to Promise<void>

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5725,7 +5725,7 @@ interface HTMLMediaElement extends HTMLElement {
     /**
       * Loads and starts playback of a media resource.
       */
-    play(): void;
+    play(): Promise<void>;
     setMediaKeys(mediaKeys: MediaKeys | null): Promise<void>;
     readonly HAVE_CURRENT_DATA: number;
     readonly HAVE_ENOUGH_DATA: number;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1073,5 +1073,13 @@
         "signatures": [
             "new(data?: string): Text"
         ]
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLMediaElement",
+        "name": "play",
+        "signatures": [
+            "play(): Promise<void>"
+        ]
     }
  ]


### PR DESCRIPTION
Closes issue #15691

https://github.com/Microsoft/TypeScript/issues/15691

* Previously the return type was void
* According to https://html.spec.whatwg.org/multipage/embedded-content.html#dom-media-play it should be Promise<void>