### PR TITLE
Add tooShort to ValidityState

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -11880,6 +11880,7 @@ interface ValidityState {
     readonly typeMismatch: boolean;
     readonly valid: boolean;
     readonly valueMissing: boolean;
+    readonly tooShort: boolean;
 }
 
 declare var ValidityState: {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1622,5 +1622,13 @@
         "name": "InsertPosition",
         "flavor": "Web",
         "type": "\"beforebegin\" | \"afterbegin\" | \"beforeend\" | \"afterend\""
+    },
+    {
+        "kind": "property",
+        "interface": "ValidityState",
+        "name": "tooShort",
+        "flavor": "Web",
+        "readonly": true,
+        "type": "boolean"
     }
 ]


### PR DESCRIPTION
Copy-pasted from issue #257:

ValidityState is missing tooShort:
```ts
interface ValidityState {
    readonly badInput: boolean;
    readonly customError: boolean;
    readonly patternMismatch: boolean;
    readonly rangeOverflow: boolean;
    readonly rangeUnderflow: boolean;
    readonly stepMismatch: boolean;
    readonly tooLong: boolean;
    // missing => readonly tooShort: boolean;
    readonly typeMismatch: boolean;
    readonly valid: boolean;
    readonly valueMissing: boolean;
}
```

See https://github.com/Microsoft/TSJS-lib-generator/blob/475f27eacbec630695df8ae7b38ebeff2926b92f/baselines/dom.generated.d.ts#L11872

See MDN doc: https://developer.mozilla.org/en-US/docs/Web/API/ValidityState
See HTML 5.0 spec: https://www.w3.org/TR/html5/forms.html#validitystate
See HTML 5.2 spec (draft): https://www.w3.org/TR/html52/sec-forms.html#validitystate
