### PR TITLE
Add navigator.languages

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8224,6 +8224,7 @@ interface Navigator extends Object, NavigatorID, NavigatorOnLine, NavigatorConte
     readonly serviceWorker: ServiceWorkerContainer;
     readonly webdriver: boolean;
     readonly hardwareConcurrency: number;
+    readonly languages: string[];
     getGamepads(): Gamepad[];
     javaEnabled(): boolean;
     msLaunchUri(uri: string, successCallback?: MSLaunchUriCallback, noHandlerCallback?: MSLaunchUriCallback): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -552,6 +552,13 @@
     },
     {
         "kind": "property",
+        "interface": "Navigator",
+        "name": "languages",
+        "readonly": true,
+        "type": "string[]"
+    },
+    {
+        "kind": "property",
         "interface": "WorkerNavigator",
         "name": "hardwareConcurrency",
         "readonly": true,


### PR DESCRIPTION
`navigator.languages` is currently not being provided along with the DOM type definitions, this PR adds it.

From the HTML 5.1 W3Cw spec:

> `window.navigator.languages`
>     Returns an array of language tags representing the user’s preferred languages, with the most preferred language first. The most preferred language is the one returned by navigator.language. 

https://www.w3.org/TR/2016/REC-html51-20161101/webappapis.html#language-preferences

TypeScript issue:

https://github.com/Microsoft/TypeScript/issues/16246