### PR TITLE
fix FilePropertyBag should extends BlobPropertyBag according to standard

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13924,8 +13924,7 @@ interface BlobPropertyBag {
     endings?: string;
 }
 
-interface FilePropertyBag {
-    type?: string;
+interface FilePropertyBag extends BlobPropertyBag {
     lastModified?: number;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1562,8 +1562,7 @@ interface BlobPropertyBag {
     endings?: string;
 }
 
-interface FilePropertyBag {
-    type?: string;
+interface FilePropertyBag extends BlobPropertyBag {
     lastModified?: number;
 }
 

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -300,11 +300,8 @@
     {
         "kind": "interface",
         "name": "FilePropertyBag",
+        "extends": "BlobPropertyBag",
         "properties": [
-            {
-                "name": "type?",
-                "type": "string"
-            },
             {
                 "name": "lastModified?",
                 "type": "number"


### PR DESCRIPTION
FilePropertyBag should extends BlobPropertyBag according to standard: https://github.com/Microsoft/TypeScript/issues/16400