### PR TITLE
Add valid init types to URLSearchParams constructor

### DIFF
--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -182,7 +182,7 @@
         "kind": "interface",
         "name": "URLSearchParams",
         "constructorSignatures": [
-            "new (init?: string | URLSearchParams): URLSearchParams"
+            "new (init?: string | { [key: string]: string } | [string, string][] | URLSearchParams): URLSearchParams"
         ],
         "methods": [
             {


### PR DESCRIPTION
See https://url.spec.whatwg.org/#interface-urlsearchparams
Added sequence<sequence<USVString>> and record<USVString, USVString>.

Fixes https://github.com/Microsoft/TypeScript/issues/15338