### PR TITLE
fix: Type of `this` for XMLHttpRequest properties

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13823,13 +13823,13 @@ interface XMLHttpRequestEventTargetEventMap {
 }
 
 interface XMLHttpRequestEventTarget {
-    onabort: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onerror: (this: XMLHttpRequestEventTarget, ev: ErrorEvent) => any;
-    onload: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onloadend: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
-    onloadstart: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onprogress: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
-    ontimeout: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
+    onabort: (this: XMLHttpRequest, ev: Event) => any;
+    onerror: (this: XMLHttpRequest, ev: ErrorEvent) => any;
+    onload: (this: XMLHttpRequest, ev: Event) => any;
+    onloadend: (this: XMLHttpRequest, ev: ProgressEvent) => any;
+    onloadstart: (this: XMLHttpRequest, ev: Event) => any;
+    onprogress: (this: XMLHttpRequest, ev: ProgressEvent) => any;
+    ontimeout: (this: XMLHttpRequest, ev: ProgressEvent) => any;
     addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(type: K, listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1248,13 +1248,13 @@ interface XMLHttpRequestEventTargetEventMap {
 }
 
 interface XMLHttpRequestEventTarget {
-    onabort: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onerror: (this: XMLHttpRequestEventTarget, ev: ErrorEvent) => any;
-    onload: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onloadend: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
-    onloadstart: (this: XMLHttpRequestEventTarget, ev: Event) => any;
-    onprogress: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
-    ontimeout: (this: XMLHttpRequestEventTarget, ev: ProgressEvent) => any;
+    onabort: (this: XMLHttpRequest, ev: Event) => any;
+    onerror: (this: XMLHttpRequest, ev: ErrorEvent) => any;
+    onload: (this: XMLHttpRequest, ev: Event) => any;
+    onloadend: (this: XMLHttpRequest, ev: ProgressEvent) => any;
+    onloadstart: (this: XMLHttpRequest, ev: Event) => any;
+    onprogress: (this: XMLHttpRequest, ev: ProgressEvent) => any;
+    ontimeout: (this: XMLHttpRequest, ev: ProgressEvent) => any;
     addEventListener<K extends keyof XMLHttpRequestEventTargetEventMap>(type: K, listener: (this: XMLHttpRequestEventTarget, ev: XMLHttpRequestEventTargetEventMap[K]) => any, useCapture?: boolean): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, useCapture?: boolean): void;
 }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -114,6 +114,54 @@
         "signatures": ["pixelStorei(pname: number, param: number | boolean): void"]
     },
     {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onload",
+        "type": "(this: XMLHttpRequest, ev: Event) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onabort",
+        "type": "(this: XMLHttpRequest, ev: Event) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onerror",
+        "type": "(this: XMLHttpRequest, ev: ErrorEvent) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onloadend",
+        "type": "(this: XMLHttpRequest, ev: ProgressEvent) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onloadstart",
+        "type": "(this: XMLHttpRequest, ev: Event) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onprogress",
+        "type": "(this: XMLHttpRequest, ev: ProgressEvent) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "onprogress",
+        "type": "(this: XMLHttpRequest, ev: ProgressEvent) => any"
+    },
+    {
+        "kind": "property",
+        "interface": "XMLHttpRequestEventTarget",
+        "name": "ontimeout",
+        "type": "(this: XMLHttpRequest, ev: ProgressEvent) => any"
+    },
+    {
         "kind": "method",
         "interface": "XMLHttpRequest",
         "name": "send",


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/15101

This will change the type of `this` inside the functions for
* `onload`
* `onloadstart`
* `onloadend`
* `onabort`
* `onprogress`
* `ontimeout`
* `onerror`

in both `XMLHttpRequest` and `XMLHttpRequestUpload`.