### PR TITLE
Change type from Element to HTMLElement for getElementsByClassName

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3219,7 +3219,7 @@ interface Document extends Node, GlobalEventHandlers, NodeSelector, DocumentEven
      * @param elementId String that specifies the ID value. Case-insensitive.
      */
     getElementById(elementId: string): HTMLElement | null;
-    getElementsByClassName(classNames: string): HTMLCollectionOf<Element>;
+    getElementsByClassName(classNames: string): HTMLCollectionOf<HTMLElement>;
     /**
      * Gets a collection of objects based on the value of the NAME or ID attribute.
      * @param elementName Gets a collection of objects based on the value of the NAME or ID attribute.

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -176,7 +176,7 @@
     {
         "kind": "method",
         "name": "getElementsByClassName",
-        "signatures": ["getElementsByClassName(classNames: string): HTMLCollectionOf<Element>"]
+        "signatures": ["getElementsByClassName(classNames: string): HTMLCollectionOf<HTMLElement>"]
     },
     {
         "kind": "method",


### PR DESCRIPTION
Looks like this was changed from NodeList to HTMLCollection, but the element type was never changed from Element to HTMLElement.

Relevant issues: https://github.com/Microsoft/TypeScript/issues/13297 https://github.com/Microsoft/TypeScript/issues/17470

Thanks @weswigham for the help with this.