### PR TITLE
Add Path2D string constructor

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8542,6 +8542,7 @@ interface Path2D extends Object, CanvasPathMethods {
 declare var Path2D: {
     prototype: Path2D;
     new(path?: Path2D): Path2D;
+    new(d: string): Path2D;
 };
 
 interface PaymentAddress {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1131,5 +1131,13 @@
         "signatures": [
             "new(type: \"drag\" | \"dragend\" | \"dragenter\" | \"dragexit\" | \"dragleave\" | \"dragover\" | \"dragstart\" | \"drop\", dragEventInit?: { dataTransfer?: DataTransfer }): DragEvent"
         ]
+    },
+    {
+        "kind": "constructor",
+        "interface": "Path2D",
+        "signatures": [
+            "new(path?: Path2D): Path2D",
+            "new(d: string): Path2D"
+        ]
     }
  ]


### PR DESCRIPTION
Per https://github.com/Microsoft/TypeScript/issues/14660, Path2D should have a constructor overload that takes a single `string.  This [must be added here](https://github.com/Microsoft/TSJS-lib-generator#when-should-a-dom-api-be-included-here) to be consistent with [the WhatWG Canvas spec](https://html.spec.whatwg.org/multipage/canvas.html#dom-path2d), which is a Living Standard.