### PR TITLE
Restrict the views accepted by crypto.getRandomValues

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13748,7 +13748,7 @@ interface NodeSelector {
 }
 
 interface RandomSource {
-    getRandomValues<T extends ArrayBufferView>(array: T): T;
+    getRandomValues<T extends Int8Array | Uint8ClampedArray | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array>(array: T): T;
 }
 
 interface SVGAnimatedPoints {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1137,7 +1137,7 @@
         "interface": "RandomSource",
         "name": "getRandomValues",
         "signatures": [
-            "getRandomValues<T extends ArrayBufferView>(array: T): T"
+            "getRandomValues<T extends Int8Array | Uint8ClampedArray | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array>(array: T): T"
         ]
     }
  ]


### PR DESCRIPTION
to `Int8Array | Uint8ClampedArray | Uint8Array | Int16Array | Uint16Array | Int32Array | Uint32Array`, persuant to [the latest reccomendation](https://www.w3.org/TR/WebCryptoAPI/#Crypto-method-getRandomValues).