### PR TITLE
Update to WHATWG DOM Living Standard for Events

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -137,7 +137,7 @@ interface ErrorEventInit extends EventInit {
 }
 
 interface EventInit {
-    scoped?: boolean;
+    composed?: boolean;
     bubbles?: boolean;
     cancelable?: boolean;
 }
@@ -3662,12 +3662,12 @@ interface Event {
     readonly target: EventTarget;
     readonly timeStamp: number;
     readonly type: string;
-    readonly scoped: boolean;
+    readonly composed: boolean;
     initEvent(eventTypeArg: string, canBubbleArg: boolean, cancelableArg: boolean): void;
     preventDefault(): void;
     stopImmediatePropagation(): void;
     stopPropagation(): void;
-    deepPath(): EventTarget[];
+    composedPath(): EventTarget[];
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -21,7 +21,7 @@ interface CloseEventInit extends EventInit {
 }
 
 interface EventInit {
-    scoped?: boolean;
+    composed?: boolean;
     bubbles?: boolean;
     cancelable?: boolean;
 }
@@ -383,12 +383,12 @@ interface Event {
     readonly target: EventTarget;
     readonly timeStamp: number;
     readonly type: string;
-    readonly scoped: boolean;
+    readonly composed: boolean;
     initEvent(eventTypeArg: string, canBubbleArg: boolean, cancelableArg: boolean): void;
     preventDefault(): void;
     stopImmediatePropagation(): void;
     stopPropagation(): void;
-    deepPath(): EventTarget[];
+    composedPath(): EventTarget[];
     readonly AT_TARGET: number;
     readonly BUBBLING_PHASE: number;
     readonly CAPTURING_PHASE: number;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1509,21 +1509,21 @@
     {
         "kind": "property",
         "interface": "EventInit",
-        "name": "scoped?",
+        "name": "composed?",
         "type": "boolean"
     },
     {
         "kind": "property",
         "interface": "Event",
-        "name": "scoped",
+        "name": "composed",
         "type": "boolean",
         "readonly": true
     },
     {
         "kind": "method",
         "interface": "Event",
-        "name": "deepPath",
-        "signatures": ["deepPath(): EventTarget[]"]
+        "name": "composedPath",
+        "signatures": ["composedPath(): EventTarget[]"]
     },
     {
         "kind": "interface",


### PR DESCRIPTION
Referencing this issue - https://github.com/Microsoft/TypeScript/issues/17974

[WHATWG DOM Living Standard](https://dom.spec.whatwg.org/) includes [composed](https://dom.spec.whatwg.org/#dom-event-composed) and [composedPath](https://dom.spec.whatwg.org/#dom-event-composedpath) properties instead of scoped and deepPath. This will allow proper syntax for a case like the following:

```ts
this.dispatchEvent(new CustomEvent('update-term', { detail: { term: this.term }, bubbles: true, composed: true }));
```