### PR TITLE
Fix https://github.com/Microsoft/TypeScript/issues/18073

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3885,7 +3885,7 @@ interface Headers {
 
 declare var Headers: {
     prototype: Headers;
-    new(init?: Headers | string[][]): Headers;
+    new (init?: Headers | string[][] | object): Headers;;
 };
 
 interface History {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -470,7 +470,7 @@ interface Headers {
 
 declare var Headers: {
     prototype: Headers;
-    new(init?: Headers | string[][]): Headers;
+    new (init?: Headers | string[][] | object): Headers;;
 };
 
 interface IDBCursor {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1376,5 +1376,12 @@
         "readonly": true,
         "name": "form",
         "type": "HTMLFormElement | null"
+    },
+    {
+        "kind": "constructor",
+        "interface": "Headers",
+        "signatures": [
+            "new (init?: Headers | string[][] | object): Headers;"
+        ]
     }
  ]


### PR DESCRIPTION
From https://fetch.spec.whatwg.org/#headers-class

> typedef (sequence<sequence<ByteString>> or record<ByteString, ByteString>) HeadersInit;

it also can be a `Headers` object. which is a bit redundant.
