### PR TITLE
Change return type of window.open to Window | null (#18132)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ The common steps to send a pull request are:
 
 0. Open or refer to an issue in the [TypeScript repo](https://github.com/Microsoft/TypeScript).
 1. Add missing elements to `inputfiles/addedTypes.json`, overriding elements to `inputfiles/overridingTypes.json`, or elements to remove to `inputfiles/removedTypes.json`.
-2. Run the script locally to obtain new `dom.generated.d.ts` and `webworker.generated.d.ts`.
-3. Update the files in the `baselines` folder using the newly generated files.
+2. Run the build script locally to obtain new `dom.generated.d.ts` and `webworker.generated.d.ts`.
+3. Update the files in the `baselines` folder using the newly generated files
+   under `generated` folder (`cp ./generated/* ./baseline/`).
 
 ### When should a DOM API be included here?
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13277,7 +13277,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     moveBy(x?: number, y?: number): void;
     moveTo(x?: number, y?: number): void;
     msWriteProfilerMark(profilerMarkName: string): void;
-    open(url?: string, target?: string, features?: string, replace?: boolean): Window;
+    open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
     postMessage(message: any, targetOrigin: string, transfer?: any[]): void;
     print(): void;
     prompt(message?: string, _default?: string): string | null;
@@ -14677,7 +14677,7 @@ declare function matchMedia(mediaQuery: string): MediaQueryList;
 declare function moveBy(x?: number, y?: number): void;
 declare function moveTo(x?: number, y?: number): void;
 declare function msWriteProfilerMark(profilerMarkName: string): void;
-declare function open(url?: string, target?: string, features?: string, replace?: boolean): Window;
+declare function open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
 declare function postMessage(message: any, targetOrigin: string, transfer?: any[]): void;
 declare function print(): void;
 declare function prompt(message?: string, _default?: string): string | null;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -615,7 +615,7 @@
         "kind": "method",
         "interface": "Window",
         "name": "open",
-        "signatures": ["open(url?: string, target?: string, features?: string, replace?: boolean): Window"]
+        "signatures": ["open(url?: string, target?: string, features?: string, replace?: boolean): Window | null"]
     },
     {
         "kind": "method",


### PR DESCRIPTION
Update return type signature of `window.open` from `Window` to `Window | null`. Solves [Microsoft/TypeScript/#18132](https://github.com/Microsoft/TypeScript/issues/18132#issuecomment-327313732).

Also, I made a slight change to the common PR steps section of README - I thought being more explicit could help a very beginner (like myself).