### PR TITLE
fix #19200 PaymentMethodData.supportedMethods

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -708,7 +708,7 @@ interface PaymentItem {
 
 interface PaymentMethodData {
     data?: any;
-    supportedMethods: string[];
+    supportedMethods: string;
 }
 
 interface PaymentOptions {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1605,5 +1605,11 @@
         "interface": "ResponseInit",
         "name": "headers?",
         "type": "HeadersInit"
+    },
+    {
+        "kind": "property",
+        "interface": "PaymentMethodData",
+        "name": "supportedMethods",
+        "type": "string"
     }
 ]


### PR DESCRIPTION
This addresses TypeScript issue https://github.com/Microsoft/TypeScript/issues/19200. As per https://www.w3.org/TR/payment-request/#paymentmethoddata-dictionary, supportedMethods was changed from an array to a string, but the name was left plural.