### PR TITLE
Add generic type to closest method of Element.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3627,6 +3627,7 @@ interface Element extends Node, GlobalEventHandlers, ElementTraversal, NodeSelec
     getElementsByClassName(classNames: string): NodeListOf<Element>;
     matches(selector: string): boolean;
     closest(selector: string): Element | null;
+    closest<K extends keyof ElementTagNameMap>(selector: K): ElementTagNameMap[K] | null;
     scrollIntoView(arg?: boolean | ScrollIntoViewOptions): void;
     scroll(options?: ScrollToOptions): void;
     scroll(x: number, y: number): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3626,8 +3626,8 @@ interface Element extends Node, GlobalEventHandlers, ElementTraversal, NodeSelec
     webkitRequestFullScreen(): void;
     getElementsByClassName(classNames: string): NodeListOf<Element>;
     matches(selector: string): boolean;
-    closest(selector: string): Element | null;
     closest<K extends keyof ElementTagNameMap>(selector: K): ElementTagNameMap[K] | null;
+    closest(selector: string): Element | null;
     scrollIntoView(arg?: boolean | ScrollIntoViewOptions): void;
     scroll(options?: ScrollToOptions): void;
     scroll(x: number, y: number): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -462,6 +462,13 @@
         ]
     },
     {
+        "kind": "method",
+        "interface": "Element",
+        "signatures": [
+            "closest<K extends keyof ElementTagNameMap>(selector: K): ElementTagNameMap[K] | null"
+        ]
+    },
+    {
         "kind": "typedef",
         "flavor": "Web",
         "name": "ScrollBehavior",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -458,14 +458,14 @@
         "kind": "method",
         "interface": "Element",
         "signatures": [
-            "closest(selector: string): Element | null"
+            "closest<K extends keyof ElementTagNameMap>(selector: K): ElementTagNameMap[K] | null"
         ]
     },
     {
         "kind": "method",
         "interface": "Element",
         "signatures": [
-            "closest<K extends keyof ElementTagNameMap>(selector: K): ElementTagNameMap[K] | null"
+            "closest(selector: string): Element | null"
         ]
     },
     {


### PR DESCRIPTION
This pull request will allow the Element `closest` method to infer the HTML Element type rather than returning a generic Element.