### PR TITLE
Add overrides for interface types and add CustomEvent types for testing.

### DIFF
--- a/TS.fsx
+++ b/TS.fsx
@@ -160,7 +160,6 @@ module InputJson =
         | SignatureOverload
         | TypeDef
         | Extends
-        | TypedInterface
         override x.ToString() =
             match x with
             | Property _ -> "property"
@@ -173,7 +172,6 @@ module InputJson =
             | SignatureOverload _ -> "signatureoverload"
             | TypeDef _ -> "typedef"
             | Extends _ -> "extends"
-            | TypedInterface _ -> "typedinterface"
 
     let getItemByName (allItems: InputJsonType.Root []) (itemName: string) (kind: ItemKind) otherFilter =
         let filter (item: InputJsonType.Root) =
@@ -782,8 +780,8 @@ module Emit =
         m.Params.Length = 1 &&
         (DomTypeToTsType m.Params.[0].Type) = expectedParamType
     let processInterfaceType iName =
-        match getOverriddenItems ItemKind.TypedInterface Flavor.All |> Array.tryFind (matchInterface iName) with
-        | Some it -> iName + "<" + (it.Parameters |> String.concat ", ") + ">"
+        match getOverriddenItems ItemKind.Interface Flavor.All |> Array.tryFind (matchInterface iName) with
+        | Some it -> iName + "<" + (it.TypeParameters |> String.concat ", ") + ">"
         | _ -> iName
 
     /// Emit overloads for the createElement method

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -83,7 +83,7 @@ interface ConstrainVideoFacingModeParameters {
 }
 
 interface CustomEventInit<T = any> extends EventInit {
-    detail: T;
+    detail?: T;
 }
 
 interface DeviceAccelerationDict {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2376,12 +2376,12 @@ declare var CSSSupportsRule: {
 
 interface CustomEvent<T = any> extends Event {
     readonly detail: T;
-    (typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void;
+    initCustomEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void;
 }
 
 declare var CustomEvent: {
     prototype: CustomEvent;
-    new(typeArg: string, eventInitDict?: CustomEventInit): CustomEvent;
+    new<T>(typeArg: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>;
 };
 
 interface DataCue extends TextTrackCue {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -82,8 +82,8 @@ interface ConstrainVideoFacingModeParameters {
     ideal?: VideoFacingModeEnum | VideoFacingModeEnum[];
 }
 
-interface CustomEventInit extends EventInit {
-    detail?: any;
+interface CustomEventInit<T = any> extends EventInit {
+    detail: T;
 }
 
 interface DeviceAccelerationDict {
@@ -2374,9 +2374,9 @@ declare var CSSSupportsRule: {
     new(): CSSSupportsRule;
 };
 
-interface CustomEvent extends Event {
-    readonly detail: any;
-    initCustomEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: any): void;
+interface CustomEvent<T = any> extends Event {
+    readonly detail: T;
+    (typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void;
 }
 
 declare var CustomEvent: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1,5 +1,40 @@
 [
     {
+        "kind": "typedinterface",
+        "interface": "CustomEventInit",
+        "parameters": [
+            "T = any"
+        ]
+    },
+    {
+        "kind": "property",
+        "interface": "CustomEventInit",
+        "name": "detail",
+        "type": "T"
+    },
+    {
+        "kind": "typedinterface",
+        "interface": "CustomEvent",
+        "parameters": [
+            "T = any"
+        ]
+    },
+    {
+        "kind": "property",
+        "interface": "CustomEvent",
+        "readonly": true,
+        "name": "detail",
+        "type": "T"
+    },
+    {
+        "kind": "method",
+        "interface": "CustomEvent",
+        "name": "initCustomEvent",
+        "signatures": [
+            "(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void"
+        ]
+    },
+    {
         "kind": "constructor",
         "interface": "Response",
         "signatures": [

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1,8 +1,8 @@
 [
     {
-        "kind": "typedinterface",
+        "kind": "interface",
         "interface": "CustomEventInit",
-        "parameters": [
+        "typeParameters": [
             "T = any"
         ]
     },
@@ -13,9 +13,9 @@
         "type": "T"
     },
     {
-        "kind": "typedinterface",
+        "kind": "interface",
         "interface": "CustomEvent",
-        "parameters": [
+        "typeParameters": [
             "T = any"
         ]
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -9,7 +9,7 @@
     {
         "kind": "property",
         "interface": "CustomEventInit",
-        "name": "detail",
+        "name": "detail?",
         "type": "T"
     },
     {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -31,7 +31,14 @@
         "interface": "CustomEvent",
         "name": "initCustomEvent",
         "signatures": [
-            "(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void"
+            "initCustomEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, detailArg: T): void"
+        ]
+    },
+    {
+        "kind": "constructor",
+        "interface": "CustomEvent",
+        "signatures": [
+            "new<T>(typeArg: string, eventInitDict?: CustomEventInit<T>): CustomEvent<T>"
         ]
     },
     {

--- a/inputfiles/sample.json
+++ b/inputfiles/sample.json
@@ -338,6 +338,13 @@
         "interface": "Document"
     },
     {
+        "kind": "typedinterface",
+        "interface": "CustomEventInit",
+        "parameters": [
+            "T = any"
+        ]
+    },
+    {
         "kind": "interface", 
         "name": "ParentNode",
         "flavor": "DOM",

--- a/inputfiles/sample.json
+++ b/inputfiles/sample.json
@@ -338,9 +338,9 @@
         "interface": "Document"
     },
     {
-        "kind": "typedinterface",
+        "kind": "interface",
         "interface": "CustomEventInit",
-        "parameters": [
+        "typeParameters": [
             "T = any"
         ]
     },


### PR DESCRIPTION
This PR will fix https://github.com/Microsoft/TypeScript/issues/14785 and replace https://github.com/Microsoft/TSJS-lib-generator/pull/304.

In order to override interfaces and add types this PR updates the TS.fsx and adds a new override type called `typedinterface`.  The naming convention was provided here https://github.com/Microsoft/TSJS-lib-generator/pull/304#issuecomment-341561311

This is my first time writing F# so please let me know if I need to make changes to the convention or if I missed an interfaces beyond Dictionaries or Interface Declarations.