### PR TITLE
Fix type declarations for "setSelectionRange" API

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5500,8 +5500,9 @@ interface HTMLInputElement extends HTMLElement {
      * Sets the start and end positions of a selection in a text field.
      * @param start The offset into the text field for the start of the selection.
      * @param end The offset into the text field for the end of the selection.
+     * @param direction The direction in which the selection is performed.
      */
-    setSelectionRange(start?: number, end?: number, direction?: string): void;
+    setSelectionRange(start: number, end: number, direction?: "forward" | "backward" | "none"): void;
     /**
      * Decrements a range input control's value by the value given by the Step attribute. If the optional parameter is used, it will decrement the input control's step value multiplied by the parameter's value.
      * @param n Value to decrement the value by.
@@ -6963,8 +6964,9 @@ interface HTMLTextAreaElement extends HTMLElement {
      * Sets the start and end positions of a selection in a text field.
      * @param start The offset into the text field for the start of the selection.
      * @param end The offset into the text field for the end of the selection.
+     * @param direction The direction in which the selection is performed.
      */
-    setSelectionRange(start: number, end: number): void;
+    setSelectionRange(start: number, end: number, direction?: "forward" | "backward" | "none"): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTextAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTextAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1948,7 +1948,7 @@
           },
           {
             "name": "setSelectionRange",
-            "comment": "/**\r\n     * Sets the start and end positions of a selection in a text field.\r\n     * @param start The offset into the text field for the start of the selection.\r\n     * @param end The offset into the text field for the end of the selection.\r\n     */"
+            "comment": "/**\r\n     * Sets the start and end positions of a selection in a text field.\r\n     * @param start The offset into the text field for the start of the selection.\r\n     * @param end The offset into the text field for the end of the selection.\r\n     * @param direction The direction in which the selection is performed.\r\n     */"
           },
           {
             "name": "select",
@@ -2335,7 +2335,7 @@
           },
           {
             "name": "setSelectionRange",
-            "comment": "/**\r\n     * Sets the start and end positions of a selection in a text field.\r\n     * @param start The offset into the text field for the start of the selection.\r\n     * @param end The offset into the text field for the end of the selection.\r\n     */"
+            "comment": "/**\r\n     * Sets the start and end positions of a selection in a text field.\r\n     * @param start The offset into the text field for the start of the selection.\r\n     * @param end The offset into the text field for the end of the selection.\r\n     * @param direction The direction in which the selection is performed.\r\n     */"
           },
           {
             "name": "select",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1739,5 +1739,21 @@
         "readonly": true,
         "name": "lastModifiedDate",
         "type": "Date"
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLInputElement",
+        "name": "setSelectionRange",
+        "signatures": [
+            "setSelectionRange(start: number, end: number, direction?: \"forward\" | \"backward\" | \"none\"): void"
+        ]
+    },
+    {
+        "kind": "method",
+        "interface": "HTMLTextAreaElement",
+        "name": "setSelectionRange",
+        "signatures": [
+            "setSelectionRange(start: number, end: number, direction?: \"forward\" | \"backward\" | \"none\"): void"
+        ]
     }
 ]


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/20419.

The `start` and `end` parameters of the [`HTMLInputElement.setSelectionRange()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement/setSelectionRange) API are _not_ optional.

In addition, the `direction` parameter only accepts one of three string values, which is why it's now typed using string literal types.