### PR TITLE
Add typemustmatch property on <object>

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6062,6 +6062,7 @@ interface HTMLObjectElement extends HTMLElement, GetSVGDocument {
      * Returns whether an element will successfully validate based on forms validation rules and constraints.
      */
     readonly willValidate: boolean;
+    typemustmatch: boolean;
     /**
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2478,6 +2478,12 @@
     },
     {
         "kind": "property",
+        "interface": "HTMLObjectElement",
+        "name": "typemustmatch",
+        "type": "boolean"
+    },
+    {
+        "kind": "property",
         "interface": "File",
         "readonly": true,
         "name": "lastModified",


### PR DESCRIPTION
As reported in TypeScript issue #20756:
https://github.com/Microsoft/TypeScript/issues/20756

Spec here:
https://html.spec.whatwg.org/multipage/iframe-embed-object.html#attr-object-typemustmatch