### PR TITLE
Remove alt attribute from HTMLObjectElement interface

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5961,10 +5961,6 @@ declare var HTMLModElement: {
 interface HTMLObjectElement extends HTMLElement, GetSVGDocument {
     align: string;
     /**
-     * Sets or retrieves a text alternative to the graphic.
-     */
-    alt: string;
-    /**
      * Gets or sets the optional alternative HTML script to execute if the object fails to load.
      */
     altHtml: string;

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -2808,10 +2808,6 @@
             "comment": "/**\r\n     * Sets or retrieves a message to be displayed while an object is loading.\r\n     */"
           },
           {
-            "name": "alt",
-            "comment": "/**\r\n     * Sets or retrieves a text alternative to the graphic.\r\n     */"
-          },
-          {
             "name": "classid",
             "comment": "/**\r\n     * Sets or retrieves the class identifier for the object.\r\n     */"
           },

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -83,5 +83,10 @@
     {
         "kind": "typedef",
         "name": "HeadersInit"
+    },
+    {
+        "kind": "property",
+        "interface": "HTMLObjectElement",
+        "name": "alt"
     }
 ]


### PR DESCRIPTION
alt is not part of the HTML Standard for HTMLObjectElement

Fixes Microsoft/TypeScript#21386