### PR TITLE
Update HTMLElement.children to return collection of HTMLElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4594,7 +4594,7 @@ interface HTMLElementEventMap extends ElementEventMap {
 
 interface HTMLElement extends Element {
     accessKey: string;
-    readonly children: HTMLCollection;
+    readonly children: HTMLCollectionOf<HTMLElement>;
     contentEditable: string;
     readonly dataset: DOMStringMap;
     dir: string;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1707,7 +1707,7 @@
         "name": "getBoundingClientRect",
         "signatures": [
             "getBoundingClientRect(): ClientRect | DOMRect"
-        ]        
+        ]
     },
     {
         "kind": "property",
@@ -1822,5 +1822,12 @@
         "signatures": [
             "getAttributeNode(name: string): Attr | null"
         ]
+    },
+    {
+        "kind": "property",
+        "interface": "HTMLElement",
+        "name": "children",
+        "readonly": true,
+        "type": "HTMLCollectionOf<HTMLElement>"
     }
 ]


### PR DESCRIPTION
I hope this is the correct location, as this is my first PR to the TypeScript project.

The listed issue states that `.children` returns a generic `HTMLCollection`. However, a `HTMLElement.children` always returns a `HTMLCollection` of `HTMLElement` itself. Therefore, override its type here with `HTMLCollectionOf` which I saw in other spots of the lib types.

Fixes https://github.com/Microsoft/TypeScript/issues/21439