### PR TITLE
HTML Elements in addedTypes.json are mapped tagName -> Interface

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15084,6 +15084,7 @@ interface HTMLElementTagNameMap {
     "script": HTMLScriptElement;
     "section": HTMLElement;
     "select": HTMLSelectElement;
+    "slot": HTMLSlotElement;
     "small": HTMLElement;
     "source": HTMLSourceElement;
     "span": HTMLSpanElement;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1575,6 +1575,7 @@
         "name": "HTMLSlotElement",
         "extends": "HTMLElement",
         "flavor": "Web",
+        "tagNames": [ "slot" ],
         "properties": [
             {
                 "name": "name",

--- a/inputfiles/sample.json
+++ b/inputfiles/sample.json
@@ -355,5 +355,26 @@
                 "type": "HTMLCollection"
             }
         ]
+    },
+    {
+        "kind": "interface",
+        "name": "HTMLSlotElement",
+        "extends": "HTMLElement",
+        "flavor": "Web",
+        "tagNames": [ "slot" ],
+        "properties": [
+            {
+                "name": "name",
+                "type": "string"
+            }
+        ],
+        "methods": [
+            {
+                "name": "assignedNodes",
+                "signatures": [
+                    "assignedNodes(options?: AssignedNodesOptions): Node[]"
+                ]
+            }
+        ]
     }
 ]


### PR DESCRIPTION
Fixing Microsoft/TypeScript#21669

See diff without whitespace changes [here](https://github.com/Microsoft/TSJS-lib-generator/compare/master...e111077:master?w=1).

Possible controversial topics in this PR:

1. I modified `inputfiles/sample.json` to include an HTML element with a `tagNames` field.
2. I added a `tagNames` field to `inputfiles/addedTypes.json`'s `HTMLSlotElement`
    1. I figured this was the correct-most way to find associations between tag names and interfaces
    2. It causes duplication of the `slot` property. See [here](https://github.com/e111077/TSJS-lib-generator/blob/3f8d2427b24442d071b2a684ed21f168c03a6861/inputfiles/addedTypes.json#L1541).
3. I added the "addedTypes" to `iNameToIDependList `'s `getExtendList` but not the `getImplementList`
    1. It was required to get through the condition in `EmitHTMLElementTagNameMap`
    2. No `InputJson.ItemKind.Interface` has an implements. This would have required more edits to `inputfiles/sample.json`.
    3. I was on the fence on whether to add it to one or none at all.

My F# is 🙅‍♂️ sharp so thanks for the review!