### PR TITLE
fix: add `escape` to `CSS`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1819,6 +1819,7 @@ declare var CryptoKeyPair: {
 };
 
 interface CSS {
+    escape(value: string): string;
     supports(property: string, value?: string): boolean;
 }
 declare var CSS: CSS;


### PR DESCRIPTION
Closes: https://github.com/Microsoft/TypeScript/issues/21090