### PR TITLE
Alias EventListenerOrEventListenerObject to EventListener

### DIFF
--- a/TS.fsx
+++ b/TS.fsx
@@ -1523,6 +1523,10 @@ module Emit =
         // Add missed interface definition from the spec
         InputJson.getAddedItems InputJson.Interface flavor |> Array.iter EmitAddedInterface
 
+        // Alias EventListener for compatibility
+        Pt.Printl "declare type EventListenerOrEventListenerObject = EventListener;"
+        Pt.Printl ""
+
         EmitCallBackFunctions flavor
 
         if flavor <> Worker then

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14924,6 +14924,8 @@ declare var Animation: {
     new(effect?: AnimationEffectReadOnly, timeline?: AnimationTimeline): Animation;
 };
 
+declare type EventListenerOrEventListenerObject = EventListener;
+
 interface DecodeErrorCallback {
     (error: DOMException): void;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1843,6 +1843,8 @@ interface EventSourceInit {
     readonly withCredentials: boolean;
 }
 
+declare type EventListenerOrEventListenerObject = EventListener;
+
 interface DecodeErrorCallback {
     (error: DOMException): void;
 }


### PR DESCRIPTION
This PR puts back `EventListenerOrEventListenerObject` as an alias to `EventEmitter`, which was removed in https://github.com/Microsoft/TSJS-lib-generator/pull/352.

This solves issues with Electron definitions, as stated in:
https://github.com/Microsoft/TypeScript/issues/21922