### PR TITLE
Improve type signature for Node#cloneNode

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8710,7 +8710,7 @@ interface Node extends EventTarget {
     readonly previousSibling: Node | null;
     textContent: string | null;
     appendChild<T extends Node>(newChild: T): T;
-    cloneNode(deep?: boolean): Node;
+    cloneNode(deep?: boolean): this;
     compareDocumentPosition(other: Node): number;
     contains(child: Node): boolean;
     hasAttributes(): boolean;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -97,6 +97,14 @@
     {
         "kind": "method",
         "interface": "Node",
+        "name": "cloneNode",
+        "signatures": [
+            "cloneNode(deep?: boolean): this"
+        ]
+    },
+    {
+        "kind": "method",
+        "interface": "Node",
         "name": "insertBefore",
         "signatures": [
             "insertBefore<T extends Node>(newChild: T, refChild: Node | null): T"


### PR DESCRIPTION
The attached pull request improves the type signature for `Node#cloneNode`.

```
    cloneNode(deep?: boolean): Node;
```

becomes

```
    cloneNode(deep?: boolean): this;
```

The cloned Node will always have the same type as the original Node.