### PR TITLE
Use `extends Typed` for the appropriate types from type.d.ts

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -152,7 +152,7 @@ export interface Interface {
         property: Record<string, Property>;
     }
     constructor?: Constructor;
-    "secure-context"?: string;
+    "secure-context"?: 1;
     implements?: string[];
     static?: 1;
     "anonymous-methods"?: {
@@ -163,12 +163,12 @@ export interface Interface {
     }
     element?: Element[];
     "named-constructor"?: NamedConstructor;
-    "override-builtins"?: string;
+    "override-builtins"?: 1;
     exposed?: string;
     tags?: string;
-    "implicit-this"?: string;
+    "implicit-this"?: 1;
     "primary-global"?: string;
-    "no-interface-object"?: string;
+    "no-interface-object"?: 1;
     global?: string;
     "type-parameters"?: string[];
     "overide-index-signatures"?: string[];

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -13,7 +13,7 @@ export type Param = {
     "nullable"?: 1;
     "type-original": string;
     "optional"?: 1;
-    "variadic"?: string;
+    "variadic"?: 1;
     "treat-null-as"?: string;
 };
 
@@ -48,7 +48,7 @@ export type Property = {
     "read-only"?: 1;
     "replaceable"?: string;
     "put-forwards"?: string;
-    "stringifier"?: string;
+    "stringifier"?: 1;
     "tags"?: string;
     "property-descriptor-not-enumerable"?: string;
     "content-attribute"?: string;
@@ -68,7 +68,7 @@ export type Property = {
     "lenient-this"?: string;
     "treat-null-as"?: string;
     "event-handler-map-to-window"?: string;
-    "static"?: string;
+    "static"?: 1;
     "comment"?: string;
     "override-type"?: string;
     "required"?: 1;
@@ -96,10 +96,10 @@ export type Event = {
 export type Method = {
     "name": string;
     "tags"?: string;
-    "static"?: string;
+    "static"?: 1;
     "getter"?: 1;
-    "stringifier"?: string;
-    "serializer"?: string;
+    "stringifier"?: 1;
+    "serializer"?: 1;
     "serializer-info"?: string;
     "comment"?: string;
     "override-signatures"?: string[];
@@ -174,7 +174,7 @@ export type Interface = {
     "constructor"?: Constructor;
     "secure-context"?: string;
     "implements"?: string[];
-    "static"?: undefined;
+    "static"?: 1;
     "anonymous-methods"?: {
         "method": Method[];
     };

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,12 +1,12 @@
-export type Typed = {
+export interface Typed {
     "type": string | Typed[];
     "subtype"?: Typed;
     "nullable"?: 1;
     "type-original"?: string;
     "override-type"?: string;
-};
+}
 
-export type Param = {
+export interface Param {
     "name": string;
     "type": string | Typed[];
     "subtype"?: Typed;
@@ -15,18 +15,18 @@ export type Param = {
     "optional"?: 1;
     "variadic"?: 1;
     "treat-null-as"?: string;
-};
+}
 
-export type Signature = {
+export interface Signature {
     "type": string | Typed[];
     "subtype"?: Typed;
     "nullable"?: 1;
     "type-original": string;
     "param"?: Param[];
     "param-min-required"?: number,
-};
+}
 
-export type Member = {
+export interface Member {
     "name": string;
     "type": string | Typed[];
     "subtype"?: Typed;
@@ -36,9 +36,9 @@ export type Member = {
     "required"?: 1;
     "override-type"?: string;
     "specs"?: string;
-};
+}
 
-export type Property = {
+export interface Property {
     "name": string;
     "event-handler"?: string;
     "type": string | Typed[];
@@ -77,9 +77,9 @@ export type Property = {
     "interop"?: 1;
     "exposed"?: string;
     "constant"?: 1;
-};
+}
 
-export type Event = {
+export interface Event {
     "name": string;
     "type": string;
     "dispatch"?: string;
@@ -91,9 +91,9 @@ export type Event = {
     "tags"?: string;
     "aliases"?: string;
     "specs"?: string;
-};
+}
 
-export type Method = {
+export interface Method {
     "name": string;
     "tags"?: string;
     "static"?: 1;
@@ -108,30 +108,30 @@ export type Method = {
     "exposed"?: string;
     "deprecated"?: 1;
     "signature": Signature[];
-};
+}
 
-export type CallbackFunction = {
+export interface CallbackFunction {
     "name": string;
     "callback": 1;
     "signature": Signature[];
     "tags"?: string;
     "override-signatures"?: string[];
     "specs"?: string;
-};
+}
 
-export type Constructor = {
+export interface Constructor {
     "signature": Signature[];
     "comment"?: string;
     "specs"?: string;
-};
+}
 
-export type NamedConstructor = {
+export interface NamedConstructor {
     "name": string;
     "signature": Signature[];
     "specs"?: string;
-};
+}
 
-export type Constant = {
+export interface Constant {
     "name": string;
     "type": string | Typed[];
     "subtype"?: Typed;
@@ -141,46 +141,46 @@ export type Constant = {
     "tags"?: string
     "exposed"?: string;
     "specs"?: string;
-};
+}
 
-export type ParsedAttribute ={
+export interface ParsedAttribute{
     "enum-values"?: string;
     "name": string;
     "value-syntax"?: string;
-};
+}
 
-export type Element = {
+export interface Element {
     "name": string;
     "namespace"?: string;
     "html-self-closing"?: string;
     "specs"?: string;
-};
+}
 
-export type Interface = {
+export interface Interface {
     "name": string;
     "extends": string;
     "constants"?: {
         "constant": Record<string, Constant>;
-    };
+    }
     "methods": {
         "method": Record<string, Method>;
-    };
+    }
     "events"?: {
         "event": Event[];
-    };
+    }
     "properties"?: {
         "property": Record<string, Property>;
-    };
+    }
     "constructor"?: Constructor;
     "secure-context"?: string;
     "implements"?: string[];
     "static"?: 1;
     "anonymous-methods"?: {
         "method": Method[];
-    };
+    }
     "anonymous-content-attributes"?: {
         "parsedattribute": ParsedAttribute[];
-    };
+    }
     "element"?: Element[];
     "named-constructor"?: NamedConstructor;
     "override-builtins"?: string;
@@ -194,50 +194,50 @@ export type Interface = {
     "overide-index-signatures"?: string[];
     "specs"?: string;
     "iterable"?: "value" | "pair" | "pair-iterator";
-};
+}
 
-export type Enum = {
+export interface Enum {
     "name": string;
     "value": string[];
     "specs"?: string;
-};
+}
 
-export type TypeDef = {
+export interface TypeDef {
     "new-type": string;
     "type": string;
     "override-type"?: string;
-};
+}
 
-export type Dictionary = {
+export interface Dictionary {
     "name": string;
     "extends": string;
     "members": {
         "member": Record<string, Member>;
-    };
+    }
     "specs"?: string;
     "type-parameters"?: string[];
-};
+}
 
-export type WebIdl = {
+export interface WebIdl {
     "callback-functions"?: {
         "callback-function": Record<string, CallbackFunction>;
     },
     "callback-interfaces"?: {
         "interface": Record<string, Interface>;
-    };
+    }
     "dictionaries"?: {
         "dictionary": Record<string, Dictionary>;
-    };
+    }
     "enums"?: {
         "enum": Record<string, Enum>;
-    };
+    }
     "interfaces"?: {
         "interface": Record<string, Interface>;
-    };
+    }
     "mixins"?: {
         "mixin": Record<string, Interface>;
-    };
+    }
     "typedefs"?: {
         "typedef": TypeDef[];
-    };
-};
+    }
+}

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -182,10 +182,8 @@ export interface Enum {
     specs?: string;
 }
 
-export interface TypeDef {
+export interface TypeDef extends Typed {
     "new-type": string;
-    type: string;
-    "override-type"?: string;
 }
 
 export interface Dictionary {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -6,45 +6,29 @@ export interface Typed {
     "override-type"?: string;
 }
 
-export interface Param {
+export interface Param extends Typed {
     name: string;
-    type: string | Typed[];
-    subtype?: Typed;
-    nullable?: 1;
-    "type-original": string;
     optional?: 1;
     variadic?: 1;
     "treat-null-as"?: string;
 }
 
-export interface Signature {
-    type: string | Typed[];
-    subtype?: Typed;
-    nullable?: 1;
-    "type-original": string;
+export interface Signature extends Typed {
     param?: Param[];
     "param-min-required"?: number,
 }
 
-export interface Member {
+export interface Member extends Typed {
     name: string;
-    type: string | Typed[];
-    subtype?: Typed;
-    nullable?: 1;
-    "type-original": string;
     default?: string;
     required?: 1;
     "override-type"?: string;
     specs?: string;
 }
 
-export interface Property {
+export interface Property extends Typed {
     name: string;
     "event-handler"?: string;
-    type: string | Typed[];
-    subtype?: Typed;
-    nullable?: 1;
-    "type-original": string;
     "read-only"?: 1;
     replaceable?: string;
     "put-forwards"?: string;
@@ -131,12 +115,8 @@ export interface NamedConstructor {
     specs?: string;
 }
 
-export interface Constant {
+export interface Constant extends Typed {
     name: string;
-    type: string | Typed[];
-    subtype?: Typed;
-    nullable?: 1;
-    "type-original": string;
     value: string;
     tags?: string
     exposed?: string;

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,55 +1,55 @@
 export interface Typed {
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original"?: string;
     "override-type"?: string;
 }
 
 export interface Param {
-    "name": string;
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    name: string;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original": string;
-    "optional"?: 1;
-    "variadic"?: 1;
+    optional?: 1;
+    variadic?: 1;
     "treat-null-as"?: string;
 }
 
 export interface Signature {
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original": string;
-    "param"?: Param[];
+    param?: Param[];
     "param-min-required"?: number,
 }
 
 export interface Member {
-    "name": string;
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    name: string;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original": string;
-    "default"?: string;
-    "required"?: 1;
+    default?: string;
+    required?: 1;
     "override-type"?: string;
-    "specs"?: string;
+    specs?: string;
 }
 
 export interface Property {
-    "name": string;
+    name: string;
     "event-handler"?: string;
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original": string;
     "read-only"?: 1;
-    "replaceable"?: string;
+    replaceable?: string;
     "put-forwards"?: string;
-    "stringifier"?: 1;
-    "tags"?: string;
+    stringifier?: 1;
+    tags?: string;
     "property-descriptor-not-enumerable"?: string;
     "content-attribute"?: string;
     "content-attribute-reflects"?: string;
@@ -68,153 +68,153 @@ export interface Property {
     "lenient-this"?: string;
     "treat-null-as"?: string;
     "event-handler-map-to-window"?: string;
-    "static"?: 1;
-    "comment"?: string;
+    static?: 1;
+    comment?: string;
     "override-type"?: string;
-    "required"?: 1;
-    "specs"?: string;
-    "deprecated"?: 1;
-    "interop"?: 1;
-    "exposed"?: string;
-    "constant"?: 1;
+    required?: 1;
+    specs?: string;
+    deprecated?: 1;
+    interop?: 1;
+    exposed?: string;
+    constant?: 1;
 }
 
 export interface Event {
-    "name": string;
-    "type": string;
-    "dispatch"?: string;
+    name: string;
+    type: string;
+    dispatch?: string;
     "skips-window"?: string;
-    "bubbles"?: 1;
-    "cancelable"?: 1;
-    "follows"?: string;
-    "precedes"?: string;
-    "tags"?: string;
-    "aliases"?: string;
-    "specs"?: string;
+    bubbles?: 1;
+    cancelable?: 1;
+    follows?: string;
+    precedes?: string;
+    tags?: string;
+    aliases?: string;
+    specs?: string;
 }
 
 export interface Method {
-    "name": string;
-    "tags"?: string;
-    "static"?: 1;
-    "getter"?: 1;
-    "stringifier"?: 1;
-    "serializer"?: 1;
+    name: string;
+    tags?: string;
+    static?: 1;
+    getter?: 1;
+    stringifier?: 1;
+    serializer?: 1;
     "serializer-info"?: string;
-    "comment"?: string;
+    comment?: string;
     "override-signatures"?: string[];
     "additional-signatures"?: string[];
-    "specs"?: string;
-    "exposed"?: string;
-    "deprecated"?: 1;
-    "signature": Signature[];
+    specs?: string;
+    exposed?: string;
+    deprecated?: 1;
+    signature: Signature[];
 }
 
 export interface CallbackFunction {
-    "name": string;
-    "callback": 1;
-    "signature": Signature[];
-    "tags"?: string;
+    name: string;
+    callback: 1;
+    signature: Signature[];
+    tags?: string;
     "override-signatures"?: string[];
-    "specs"?: string;
+    specs?: string;
 }
 
 export interface Constructor {
-    "signature": Signature[];
-    "comment"?: string;
-    "specs"?: string;
+    signature: Signature[];
+    comment?: string;
+    specs?: string;
 }
 
 export interface NamedConstructor {
-    "name": string;
-    "signature": Signature[];
-    "specs"?: string;
+    name: string;
+    signature: Signature[];
+    specs?: string;
 }
 
 export interface Constant {
-    "name": string;
-    "type": string | Typed[];
-    "subtype"?: Typed;
-    "nullable"?: 1;
+    name: string;
+    type: string | Typed[];
+    subtype?: Typed;
+    nullable?: 1;
     "type-original": string;
-    "value": string;
-    "tags"?: string
-    "exposed"?: string;
-    "specs"?: string;
+    value: string;
+    tags?: string
+    exposed?: string;
+    specs?: string;
 }
 
 export interface ParsedAttribute{
     "enum-values"?: string;
-    "name": string;
+    name: string;
     "value-syntax"?: string;
 }
 
 export interface Element {
-    "name": string;
-    "namespace"?: string;
+    name: string;
+    namespace?: string;
     "html-self-closing"?: string;
-    "specs"?: string;
+    specs?: string;
 }
 
 export interface Interface {
-    "name": string;
-    "extends": string;
-    "constants"?: {
-        "constant": Record<string, Constant>;
+    name: string;
+    extends: string;
+    constants?: {
+        constant: Record<string, Constant>;
     }
-    "methods": {
-        "method": Record<string, Method>;
+    methods: {
+        method: Record<string, Method>;
     }
-    "events"?: {
-        "event": Event[];
+    events?: {
+        event: Event[];
     }
-    "properties"?: {
-        "property": Record<string, Property>;
+    properties?: {
+        property: Record<string, Property>;
     }
-    "constructor"?: Constructor;
+    constructor?: Constructor;
     "secure-context"?: string;
-    "implements"?: string[];
-    "static"?: 1;
+    implements?: string[];
+    static?: 1;
     "anonymous-methods"?: {
-        "method": Method[];
+        method: Method[];
     }
     "anonymous-content-attributes"?: {
-        "parsedattribute": ParsedAttribute[];
+        parsedattribute: ParsedAttribute[];
     }
-    "element"?: Element[];
+    element?: Element[];
     "named-constructor"?: NamedConstructor;
     "override-builtins"?: string;
-    "exposed"?: string;
-    "tags"?: string;
+    exposed?: string;
+    tags?: string;
     "implicit-this"?: string;
     "primary-global"?: string;
     "no-interface-object"?: string;
-    "global"?: string;
+    global?: string;
     "type-parameters"?: string[];
     "overide-index-signatures"?: string[];
-    "specs"?: string;
-    "iterable"?: "value" | "pair" | "pair-iterator";
+    specs?: string;
+    iterable?: "value" | "pair" | "pair-iterator";
 }
 
 export interface Enum {
-    "name": string;
-    "value": string[];
-    "specs"?: string;
+    name: string;
+    value: string[];
+    specs?: string;
 }
 
 export interface TypeDef {
     "new-type": string;
-    "type": string;
+    type: string;
     "override-type"?: string;
 }
 
 export interface Dictionary {
-    "name": string;
-    "extends": string;
-    "members": {
-        "member": Record<string, Member>;
+    name: string;
+    extends: string;
+    members: {
+        member: Record<string, Member>;
     }
-    "specs"?: string;
+    specs?: string;
     "type-parameters"?: string[];
 }
 
@@ -223,21 +223,21 @@ export interface WebIdl {
         "callback-function": Record<string, CallbackFunction>;
     },
     "callback-interfaces"?: {
-        "interface": Record<string, Interface>;
+        interface: Record<string, Interface>;
     }
-    "dictionaries"?: {
-        "dictionary": Record<string, Dictionary>;
+    dictionaries?: {
+        dictionary: Record<string, Dictionary>;
     }
-    "enums"?: {
-        "enum": Record<string, Enum>;
+    enums?: {
+        enum: Record<string, Enum>;
     }
-    "interfaces"?: {
-        "interface": Record<string, Interface>;
+    interfaces?: {
+        interface: Record<string, Interface>;
     }
-    "mixins"?: {
-        "mixin": Record<string, Interface>;
+    mixins?: {
+        mixin: Record<string, Interface>;
     }
-    "typedefs"?: {
-        "typedef": TypeDef[];
+    typedefs?: {
+        typedef: TypeDef[];
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -22,7 +22,6 @@ export interface Member extends Typed {
     name: string;
     default?: string;
     required?: 1;
-    "override-type"?: string;
     specs?: string;
 }
 
@@ -54,7 +53,6 @@ export interface Property extends Typed {
     "event-handler-map-to-window"?: string;
     static?: 1;
     comment?: string;
-    "override-type"?: string;
     required?: 1;
     specs?: string;
     deprecated?: 1;


### PR DESCRIPTION
I've found creating some `WebIdl` types by TypeScript can be painful because of the added `"override-type"?: string;` on `Typed`.

```ts
import * as webidl2 from "webidl2"
import * as Browser from "./types";

function convertIdlType(t: webidl2.IDLTypeDescription): Browser.Typed { /* ... */ }

function convertParam(t: webidl2.Argument): Browser.Param {
  return {
    /*
     * ... some Param specific properties ...
     */
    ...convertIdlType(t.idlType) // Error: override-type does not exist in Browser.Param
  }
}
```

Those types really just extend Typed, so this PR uses `extends Typed` syntax to allow the destructuring work.