### PR TITLE
Add HTMLImageElement.decoding

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6132,6 +6132,7 @@ interface HTMLImageElement extends HTMLElement {
     readonly complete: boolean;
     crossOrigin: string | null;
     readonly currentSrc: string;
+    decoding: "async" | "sync" | "auto";
     /**
      * Sets or retrieves the height of the object.
      */

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -36,6 +36,17 @@
     },
     "interfaces": {
         "interface": {
+            "HTMLImageElement": {
+                "name": "HTMLImageElement",
+                "properties": {
+                    "property": {
+                        "decoding": {
+                            "name": "decoding",
+                            "override-type": "\"async\" | \"sync\" | \"auto\""
+                        }
+                    }
+                }
+            },
             "BroadcastChannel": {
                 "name": "BroadcastChannel",
                 "extends": "EventTarget",


### PR DESCRIPTION
[WHATWG/attr-img-decoding](https://html.spec.whatwg.org/#attr-img-decoding)

> The decoding attribute indicates the preferred method to decode this image. The attribute, if present, must be an image decoding hint. This attribute's missing value default and invalid value default are both the auto state.

Closes #392