### PR TITLE
Add type to FileReader event target.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4756,11 +4756,6 @@ interface FileReaderProgressEvent extends ProgressEvent {
     readonly target: FileReader | null;
 }
 
-declare var FileReaderProgressEvent: {
-    prototype: FileReaderProgressEvent;
-    new(): FileReaderProgressEvent;
-};
-
 interface FocusEvent extends UIEvent {
     readonly relatedTarget: EventTarget;
     initFocusEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, viewArg: Window, detailArg: number, relatedTargetArg: EventTarget): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4722,12 +4722,12 @@ interface FileReaderEventMap {
 
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent) => any) | null;
+    onabort: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onerror: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onload: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onloadend: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onloadstart: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onprogress: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
     readonly readyState: number;
     readonly result: any;
     abort(): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4722,12 +4722,12 @@ interface FileReaderEventMap {
 
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onabort: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onerror: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onload: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadend: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadstart: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onprogress: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
     readonly readyState: number;
     readonly result: any;
     abort(): void;
@@ -4750,6 +4750,15 @@ declare var FileReader: {
     readonly DONE: number;
     readonly EMPTY: number;
     readonly LOADING: number;
+};
+
+interface FileReaderProgressEvent extends ProgressEvent {
+    readonly target: FileReader | null;
+}
+
+declare var FileReaderProgressEvent: {
+    prototype: FileReaderProgressEvent;
+    new(): FileReaderProgressEvent;
 };
 
 interface FocusEvent extends UIEvent {
@@ -9682,6 +9691,12 @@ declare var PannerNode: {
 };
 
 interface ParentNode {
+    readonly childElementCount: number;
+    readonly firstElementChild: Element | null;
+    readonly lastElementChild: Element | null;
+}
+
+interface ParentNode {
     readonly children: HTMLCollection;
     querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
     querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
@@ -9689,12 +9704,6 @@ interface ParentNode {
     querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
     querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
     querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
-}
-
-interface ParentNode {
-    readonly childElementCount: number;
-    readonly firstElementChild: Element | null;
-    readonly lastElementChild: Element | null;
 }
 
 interface Path2D extends CanvasPathMethods {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -588,12 +588,12 @@ interface FileReaderEventMap {
 
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onabort: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onerror: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onload: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadend: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadstart: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onprogress: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
     readonly readyState: number;
     readonly result: any;
     abort(): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -588,12 +588,12 @@ interface FileReaderEventMap {
 
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent) => any) | null;
+    onabort: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onerror: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onload: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onloadend: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onloadstart: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
+    onprogress: ((this: FileReader, ev: ProgressEvent & {target: FileReader}) => any) | null;
     readonly readyState: number;
     readonly result: any;
     abort(): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -618,6 +618,10 @@ declare var FileReader: {
     readonly LOADING: number;
 };
 
+interface FileReaderProgressEvent extends ProgressEvent {
+    readonly target: FileReader | null;
+}
+
 interface FileReaderSync {
     readAsArrayBuffer(blob: Blob): any;
     readAsBinaryString(blob: Blob): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -47,6 +47,19 @@
                     }
                 }
             },
+            "FileReaderProgressEvent": {
+                "name": "FileReaderProgressEvent",
+                "extends": "ProgressEvent",
+                "properties": {
+                    "property": {
+                        "name": {
+                            "name": "target",
+                            "read-only": 1,
+                            "override-type": "FileReader | null"
+                        }
+                    }
+                }
+            },
             "BroadcastChannel": {
                 "name": "BroadcastChannel",
                 "extends": "EventTarget",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -58,7 +58,8 @@
                             "override-type": "FileReader | null"
                         }
                     }
-                }
+                },
+                "no-interface-object": "1"
             },
             "BroadcastChannel": {
                 "name": "BroadcastChannel",

--- a/inputfiles/knownWorkerTypes.json
+++ b/inputfiles/knownWorkerTypes.json
@@ -37,6 +37,7 @@
     "File",
     "FileList",
     "FileReader",
+    "FileReaderProgressEvent",
     "FormData",
     "Headers",
     "IDBCursor",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1763,27 +1763,27 @@
                     "property": {
                         "onloadstart": {
                             "name": "onloadstart",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "onprogress": {
                             "name": "onprogress",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "onload": {
                             "name": "onload",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "onabort": {
                             "name": "onabort",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "onerror": {
                             "name": "onerror",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "onloadend": {
                             "name": "onloadend",
-                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                            "override-type": "(this: FileReader, ev: FileReaderProgressEvent) => any"
                         },
                         "result": {
                             "name": "result",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1761,6 +1761,30 @@
                 "name": "FileReader",
                 "properties": {
                     "property": {
+                        "onloadstart": {
+                            "name": "onloadstart",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
+                        "onprogress": {
+                            "name": "onprogress",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
+                        "onload": {
+                            "name": "onload",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
+                        "onabort": {
+                            "name": "onabort",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
+                        "onerror": {
+                            "name": "onerror",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
+                        "onloadend": {
+                            "name": "onloadend",
+                            "override-type": "(this: FileReader, ev: ProgressEvent & {target: FileReader}) => any"
+                        },
                         "result": {
                             "name": "result",
                             "override-type": "any"


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/TypeScript/issues/4163.

The [FileReader API spec](https://www.w3.org/TR/FileAPI/#events) says the event target is `FileReader` so I give `FileReader` type to `target` of `ev`. 