### PR TITLE
HTMLInputElement::files should not be a read-only property

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6255,7 +6255,7 @@ interface HTMLInputElement extends HTMLElement {
     /**
      * Returns a FileList object on a file type input object.
      */
-    readonly files: FileList | null;
+    files: FileList | null;
     /**
      * Retrieves a reference to the form that the object is embedded in.
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1400,7 +1400,7 @@
                     "property": {
                         "files": {
                             "name": "files",
-                            "read-only": 1,
+                            "read-only": 0,
                             "override-type": "FileList | null"
                         },
                         "form": {


### PR DESCRIPTION
[Microsoft/TypeScript#22463](https://github.com/Microsoft/TypeScript/issues/22463)

[`HTMLInputElement::files`](https://html.spec.whatwg.org/multipage/input.html#the-input-element:dom-input-files)