### PR TITLE
Add missing methods to URLSearchParams

### DIFF
--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -420,7 +420,7 @@
                             "override-signatures": [
                                 "values(): IterableIterator<string>"
                             ]
-                        },
+                        }
                     }
                 },
                 "constructor": {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -373,6 +373,12 @@
                                 "delete(name: string): void"
                             ]
                         },
+                        "entries": {
+                            "name": "entries",
+                            "override-signatures": [
+                                "entries(): IterableIterator<[string, string]>"
+                            ]
+                        },
                         "get": {
                             "name": "get",
                             "override-signatures": [
@@ -391,12 +397,30 @@
                                 "has(name: string): boolean"
                             ]
                         },
+                        "keys": {
+                            "name": "keys",
+                            "override-signatures": [
+                                "keys(): IterableIterator<string>"
+                            ]
+                        },
                         "set": {
                             "name": "set",
                             "override-signatures": [
                                 "set(name: string, value: string): void"
                             ]
-                        }
+                        },
+                        "toString": {
+                            "name": "toString",
+                            "override-signatures": [
+                                "toString(): string"
+                            ]
+                        },
+                        "values": {
+                            "name": "values",
+                            "override-signatures": [
+                                "values(): IterableIterator<string>"
+                            ]
+                        },
                     }
                 },
                 "constructor": {


### PR DESCRIPTION
There are methods in the [spec for URLSearchParams](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) that are missing from the typings: entries, keys, toString, and values.