### PR TITLE
Change setValueCurveAtTime values to Float32Array

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1955,7 +1955,7 @@ interface AudioParam {
     linearRampToValueAtTime(value: number, endTime: number): AudioParam;
     setTargetAtTime(target: number, startTime: number, timeConstant: number): AudioParam;
     setValueAtTime(value: number, startTime: number): AudioParam;
-    setValueCurveAtTime(values: number[], startTime: number, duration: number): AudioParam;
+    setValueCurveAtTime(values: Float32Array, startTime: number, duration: number): AudioParam;
 }
 
 declare var AudioParam: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1967,6 +1967,19 @@
                         "new(d?: Path2D | string): Path2D"
                     ]
                 }
+            },
+            "AudioParam": {
+                "name": "AudioParam",
+                "methods": {
+                    "method": {
+                        "setValueCurveAtTime": {
+                            "name": "setValueCurveAtTime",
+                            "override-signatures": [
+                                "setValueCurveAtTime(values: Float32Array, startTime: number, duration: number): AudioParam"
+                            ]
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
Microsoft/TypeScript#23160

https://www.w3.org/TR/webaudio/#widl-AudioParam-setValueCurveAtTime-AudioParam-Float32Array-values-double-startTime-double-duration