### PR TITLE
Add missing methods to URLSearchParams

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -13405,6 +13405,7 @@ interface URLSearchParams {
      * Deletes the given search parameter, and its associated value, from the list of all search parameters.
      */
     delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
     /**
      * Returns the first value associated to the given search parameter.
      */
@@ -13417,10 +13418,13 @@ interface URLSearchParams {
      * Returns a Boolean indicating if such a search parameter exists.
      */
     has(name: string): boolean;
+    keys(): IterableIterator<[string, string]>;
     /**
      * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
      */
     set(name: string, value: string): void;
+    toString(): string;
+    values(): IterableIterator<[string, string]>;
 }
 
 declare var URLSearchParams: {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1400,6 +1400,7 @@ interface URLSearchParams {
      * Deletes the given search parameter, and its associated value, from the list of all search parameters.
      */
     delete(name: string): void;
+    entries(): IterableIterator<[string, string]>;
     /**
      * Returns the first value associated to the given search parameter.
      */
@@ -1412,10 +1413,13 @@ interface URLSearchParams {
      * Returns a Boolean indicating if such a search parameter exists.
      */
     has(name: string): boolean;
+    keys(): IterableIterator<[string, string]>;
     /**
      * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.
      */
     set(name: string, value: string): void;
+    toString(): string;
+    values(): IterableIterator<[string, string]>;
 }
 
 declare var URLSearchParams: {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -373,6 +373,12 @@
                                 "delete(name: string): void"
                             ]
                         },
+                        "entries": {
+                            "name": "entries",
+                            "override-signatures": [
+                                "entries(): IterableIterator<[string, string]>"
+                            ]
+                        },
                         "get": {
                             "name": "get",
                             "override-signatures": [
@@ -391,10 +397,28 @@
                                 "has(name: string): boolean"
                             ]
                         },
+                        "keys": {
+                            "name": "keys",
+                            "override-signatures": [
+                                "keys(): IterableIterator<[string, string]>"
+                            ]
+                        },
                         "set": {
                             "name": "set",
                             "override-signatures": [
                                 "set(name: string, value: string): void"
+                            ]
+                        },
+                        "toString": {
+                            "name": "toString",
+                            "override-signatures": [
+                                "toString(): string"
+                            ]
+                        },
+                        "values": {
+                            "name": "values",
+                            "override-signatures": [
+                                "values(): IterableIterator<[string, string]>"
                             ]
                         }
                     }


### PR DESCRIPTION
Add typings for methods that are specified in the URLSearchParams API but are missing in the Typescript def.