### PR TITLE
Update/use IDBValidKey

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8441,13 +8441,13 @@ interface IDBIndex {
     name: string;
     readonly objectStore: IDBObjectStore;
     readonly unique: boolean;
-    count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    get(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    getAll(query?: any, count?: number): IDBRequest;
-    getAllKeys(query?: any, count?: number): IDBRequest;
-    getKey(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
-    openKeyCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
+    count(key?: IDBValidKey | IDBKeyRange): IDBRequest;
+    get(key: IDBValidKey | IDBKeyRange): IDBRequest;
+    getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getKey(key: IDBValidKey | IDBKeyRange): IDBRequest;
+    openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    openKeyCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
 }
 
 declare var IDBIndex: {
@@ -8484,10 +8484,10 @@ interface IDBObjectStore {
     createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IDBIndex;
     delete(key: IDBValidKey | IDBKeyRange): IDBRequest;
     deleteIndex(name: string): void;
-    get(query: any): IDBRequest;
-    getAll(query?: any, count?: number): IDBRequest;
-    getAllKeys(query?: any, count?: number): IDBRequest;
-    getKey(query: any): IDBRequest;
+    get(query: IDBValidKey | IDBKeyRange): IDBRequest;
+    getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getKey(query: IDBValidKey | IDBKeyRange): IDBRequest;
     index(name: string): IDBIndex;
     openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
     openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8366,12 +8366,12 @@ interface HkdfCtrParams extends Algorithm {
 
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
-    readonly key: IDBKeyRange | number | string | Date | IDBArrayKey;
-    readonly primaryKey: any;
+    readonly key: IDBValidKey | IDBKeyRange;
+    readonly primaryKey: IDBValidKey | IDBKeyRange;
     readonly source: IDBObjectStore | IDBIndex;
     advance(count: number): void;
-    continue(key?: IDBKeyRange | number | string | Date | IDBArrayKey): void;
-    continuePrimaryKey(key: any, primaryKey: any): void;
+    continue(key?: IDBValidKey | IDBKeyRange): void;
+    continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void;
     delete(): IDBRequest;
     update(value: any): IDBRequest;
 }

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8364,9 +8364,6 @@ interface HkdfCtrParams extends Algorithm {
     label: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer;
 }
 
-interface IDBArrayKey extends Array<number | string | Date | IDBArrayKey> {
-}
-
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
     readonly key: IDBKeyRange | number | string | Date | IDBArrayKey;
@@ -8481,20 +8478,20 @@ interface IDBObjectStore {
     readonly keyPath: string | string[];
     name: string;
     readonly transaction: IDBTransaction;
-    add(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest;
     clear(): IDBRequest;
-    count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    createIndex(name: string, keyPath: string | string[], optionalParameters?: IDBIndexParameters): IDBIndex;
-    delete(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    count(key?: IDBValidKey | IDBKeyRange): IDBRequest;
+    createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IDBIndex;
+    delete(key: IDBValidKey | IDBKeyRange): IDBRequest;
     deleteIndex(name: string): void;
     get(query: any): IDBRequest;
     getAll(query?: any, count?: number): IDBRequest;
     getAllKeys(query?: any, count?: number): IDBRequest;
     getKey(query: any): IDBRequest;
     index(name: string): IDBIndex;
-    openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
-    openKeyCursor(query?: any, direction?: IDBCursorDirection): IDBRequest;
-    put(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest;
 }
 
 declare var IDBObjectStore: {
@@ -16177,7 +16174,8 @@ type ScrollRestoration = "auto" | "manual";
 type FormDataEntryValue = string | File;
 type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
 type OrientationLockType = "any" | "natural" | "portrait" | "landscape" | "portrait-primary" | "portrait-secondary" | "landscape-primary"| "landscape-secondary";
-type IDBValidKey = number | string | Date | IDBArrayKey;
+type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
+type IDBArrayKey = IDBValidKey[];
 type AlgorithmIdentifier = string | Algorithm;
 type MutationRecordType = "attributes" | "characterData" | "childList";
 type AAGUID = string;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8364,6 +8364,9 @@ interface HkdfCtrParams extends Algorithm {
     label: Int8Array | Int16Array | Int32Array | Uint8Array | Uint16Array | Uint32Array | Uint8ClampedArray | Float32Array | Float64Array | DataView | ArrayBuffer;
 }
 
+interface IDBArrayKey extends Array<IDBValidKey> {
+}
+
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
     readonly key: IDBValidKey | IDBKeyRange;
@@ -16175,7 +16178,6 @@ type FormDataEntryValue = string | File;
 type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
 type OrientationLockType = "any" | "natural" | "portrait" | "landscape" | "portrait-primary" | "portrait-secondary" | "landscape-primary"| "landscape-secondary";
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
-type IDBArrayKey = IDBValidKey[];
 type AlgorithmIdentifier = string | Algorithm;
 type MutationRecordType = "attributes" | "characterData" | "childList";
 type AAGUID = string;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -675,12 +675,12 @@ declare var Headers: {
 
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
-    readonly key: IDBKeyRange | number | string | Date | IDBArrayKey;
-    readonly primaryKey: any;
+    readonly key: IDBValidKey | IDBKeyRange;
+    readonly primaryKey: IDBValidKey | IDBKeyRange;
     readonly source: IDBObjectStore | IDBIndex;
     advance(count: number): void;
-    continue(key?: IDBKeyRange | number | string | Date | IDBArrayKey): void;
-    continuePrimaryKey(key: any, primaryKey: any): void;
+    continue(key?: IDBValidKey | IDBKeyRange): void;
+    continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void;
     delete(): IDBRequest;
     update(value: any): IDBRequest;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -746,13 +746,13 @@ interface IDBIndex {
     name: string;
     readonly objectStore: IDBObjectStore;
     readonly unique: boolean;
-    count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    get(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    getAll(query?: any, count?: number): IDBRequest;
-    getAllKeys(query?: any, count?: number): IDBRequest;
-    getKey(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
-    openKeyCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
+    count(key?: IDBValidKey | IDBKeyRange): IDBRequest;
+    get(key: IDBValidKey | IDBKeyRange): IDBRequest;
+    getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getKey(key: IDBValidKey | IDBKeyRange): IDBRequest;
+    openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    openKeyCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
 }
 
 declare var IDBIndex: {
@@ -789,10 +789,10 @@ interface IDBObjectStore {
     createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IDBIndex;
     delete(key: IDBValidKey | IDBKeyRange): IDBRequest;
     deleteIndex(name: string): void;
-    get(query: any): IDBRequest;
-    getAll(query?: any, count?: number): IDBRequest;
-    getAllKeys(query?: any, count?: number): IDBRequest;
-    getKey(query: any): IDBRequest;
+    get(query: IDBValidKey | IDBKeyRange): IDBRequest;
+    getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest;
+    getKey(query: IDBValidKey | IDBKeyRange): IDBRequest;
     index(name: string): IDBIndex;
     openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
     openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -673,6 +673,9 @@ declare var Headers: {
     new(init?: HeadersInit): Headers;
 };
 
+interface IDBArrayKey extends Array<IDBValidKey> {
+}
+
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
     readonly key: IDBValidKey | IDBKeyRange;
@@ -1772,7 +1775,6 @@ type PerformanceEntryList = PerformanceEntry[];
 type BufferSource = ArrayBufferView | ArrayBuffer;
 type FormDataEntryValue = string | File;
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
-type IDBArrayKey = IDBValidKey[];
 type AlgorithmIdentifier = string | Algorithm;
 type AAGUID = string;
 type ByteString = string;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -673,9 +673,6 @@ declare var Headers: {
     new(init?: HeadersInit): Headers;
 };
 
-interface IDBArrayKey extends Array<number | string | Date | IDBArrayKey> {
-}
-
 interface IDBCursor {
     readonly direction: IDBCursorDirection;
     readonly key: IDBKeyRange | number | string | Date | IDBArrayKey;
@@ -786,20 +783,20 @@ interface IDBObjectStore {
     readonly keyPath: string | string[];
     name: string;
     readonly transaction: IDBTransaction;
-    add(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest;
     clear(): IDBRequest;
-    count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
-    createIndex(name: string, keyPath: string | string[], optionalParameters?: IDBIndexParameters): IDBIndex;
-    delete(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    count(key?: IDBValidKey | IDBKeyRange): IDBRequest;
+    createIndex(name: string, keyPath: string | string[], options?: IDBIndexParameters): IDBIndex;
+    delete(key: IDBValidKey | IDBKeyRange): IDBRequest;
     deleteIndex(name: string): void;
     get(query: any): IDBRequest;
     getAll(query?: any, count?: number): IDBRequest;
     getAllKeys(query?: any, count?: number): IDBRequest;
     getKey(query: any): IDBRequest;
     index(name: string): IDBIndex;
-    openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest;
-    openKeyCursor(query?: any, direction?: IDBCursorDirection): IDBRequest;
-    put(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest;
+    openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest;
+    put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest;
 }
 
 declare var IDBObjectStore: {
@@ -1774,6 +1771,8 @@ type RequestInfo = Request | string;
 type PerformanceEntryList = PerformanceEntry[];
 type BufferSource = ArrayBufferView | ArrayBuffer;
 type FormDataEntryValue = string | File;
+type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
+type IDBArrayKey = IDBValidKey[];
 type AlgorithmIdentifier = string | Algorithm;
 type AAGUID = string;
 type ByteString = string;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -824,6 +824,11 @@
                 },
                 "no-interface-object": "1"
             },
+            "IDBArrayKey": {
+                "name": "IDBArrayKey",
+                "extends": "Array<IDBValidKey>",
+                "no-interface-object": "1"
+            },
             "HTMLInputElement": {
                 "name": "HTMLInputElement",
                 "properties": {
@@ -2847,10 +2852,6 @@
             {
                 "override-type": "number | string | Date | BufferSource | IDBArrayKey",
                 "new-type": "IDBValidKey"
-            },
-            {
-                "override-type": "IDBValidKey[]",
-                "new-type": "IDBArrayKey"
             },
             {
                 "override-type": "string | Algorithm",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -332,17 +332,6 @@
                     }
                 }
             },
-            "IDBIndex": {
-                "name": "IDBIndex",
-                "properties": {
-                    "property": {
-                        "multiEntry": {
-                            "name": "multiEntry",
-                            "override-type": "boolean"
-                        }
-                    }
-                }
-            },
             "URLSearchParams": {
                 "name": "URLSearchParams",
                 "methods": {
@@ -815,17 +804,6 @@
                     }
                 }
             },
-            "IDBObjectStore": {
-                "name": "IDBObjectStore",
-                "properties": {
-                    "property": {
-                        "autoIncrement": {
-                            "name": "autoIncrement",
-                            "override-type": "boolean"
-                        }
-                    }
-                }
-            },
             "ClipboardEventInit": {
                 "flavor": "Web",
                 "name": "ClipboardEventInit",
@@ -844,11 +822,6 @@
                         }
                     }
                 },
-                "no-interface-object": "1"
-            },
-            "IDBArrayKey": {
-                "name": "IDBArrayKey",
-                "extends": "Array<number | string | Date | IDBArrayKey>",
                 "no-interface-object": "1"
             },
             "HTMLInputElement": {
@@ -2872,8 +2845,12 @@
                 "new-type": "OrientationLockType"
             },
             {
-                "override-type": "number | string | Date | IDBArrayKey",
+                "override-type": "number | string | Date | BufferSource | IDBArrayKey",
                 "new-type": "IDBValidKey"
+            },
+            {
+                "override-type": "IDBValidKey[]",
+                "new-type": "IDBArrayKey"
             },
             {
                 "override-type": "string | Algorithm",

--- a/inputfiles/knownWorkerTypes.json
+++ b/inputfiles/knownWorkerTypes.json
@@ -184,6 +184,7 @@
     "URLSearchParams",
     "BlobPropertyBag",
     "FilePropertyBag",
+    "IDBValidKey",
     "IDBArrayKey",
     "IDBVersionChangeEventInit",
     "BufferSource"

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -539,6 +539,30 @@
                             "override-signatures": [
                                 "put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
+                        },
+                        "get": {
+                            "name": "get",
+                            "override-signatures": [
+                                "get(query: IDBValidKey | IDBKeyRange): IDBRequest"
+                            ]
+                        },
+                        "getAll": {
+                            "name": "getAll",
+                            "override-signatures": [
+                                "getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest"
+                            ]
+                        },
+                        "getAllKeys": {
+                            "name": "getAllKeys",
+                            "override-signatures": [
+                                "getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest"
+                            ]
+                        },
+                        "getKey": {
+                            "name": "getKey",
+                            "override-signatures": [
+                                "getKey(query: IDBValidKey | IDBKeyRange): IDBRequest"
+                            ]
                         }
                     }
                 },
@@ -583,31 +607,43 @@
                         "openCursor": {
                             "name": "openCursor",
                             "override-signatures": [
-                                "openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest"
+                                "openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest"
                             ]
                         },
                         "openKeyCursor": {
                             "name": "openKeyCursor",
                             "override-signatures": [
-                                "openKeyCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest"
+                                "openKeyCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest"
                             ]
                         },
                         "count": {
                             "name": "count",
                             "override-signatures": [
-                                "count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "count(key?: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         },
                         "get": {
                             "name": "get",
                             "override-signatures": [
-                                "get(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "get(key: IDBValidKey | IDBKeyRange): IDBRequest"
+                            ]
+                        },
+                        "getAll": {
+                            "name": "getAll",
+                            "override-signatures": [
+                                "getAll(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest"
+                            ]
+                        },
+                        "getAllKeys": {
+                            "name": "getAllKeys",
+                            "override-signatures": [
+                                "getAllKeys(query?: IDBValidKey | IDBKeyRange, count?: number): IDBRequest"
                             ]
                         },
                         "getKey": {
                             "name": "getKey",
                             "override-signatures": [
-                                "getKey(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "getKey(key: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1314,13 +1314,13 @@
                 "name": "IDBCursor",
                 "properties": {
                     "property": {
-                        "source": {
-                            "name": "source",
-                            "override-type": "IDBObjectStore | IDBIndex"
-                        },
                         "key": {
                             "name": "key",
-                            "override-type": "IDBKeyRange | number | string | Date | IDBArrayKey"
+                            "override-type": "IDBValidKey | IDBKeyRange"
+                        },
+                        "primaryKey": {
+                            "name": "primaryKey",
+                            "override-type": "IDBValidKey | IDBKeyRange"
                         }
                     }
                 },
@@ -1329,7 +1329,13 @@
                         "continue": {
                             "name": "continue",
                             "override-signatures": [
-                                "continue(key?: IDBKeyRange | number | string | Date | IDBArrayKey): void"
+                                "continue(key?: IDBValidKey | IDBKeyRange): void"
+                            ]
+                        },
+                        "continuePrimaryKey": {
+                            "name": "continuePrimaryKey",
+                            "override-signatures": [
+                                "continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -504,40 +504,40 @@
                 "name": "IDBObjectStore",
                 "methods": {
                     "method": {
-                        "createIndex": {
-                            "name": "createIndex",
-                            "override-signatures": [
-                                "createIndex(name: string, keyPath: string | string[], optionalParameters?: IDBIndexParameters): IDBIndex"
-                            ]
-                        },
                         "openCursor": {
                             "name": "openCursor",
                             "override-signatures": [
-                                "openCursor(range?: IDBKeyRange | number | string | Date | IDBArrayKey, direction?: IDBCursorDirection): IDBRequest"
+                                "openCursor(range?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest"
+                            ]
+                        },
+                        "openKeyCursor": {
+                            "name": "openKeyCursor",
+                            "override-signatures": [
+                                "openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest"
                             ]
                         },
                         "add": {
                             "name": "add",
                             "override-signatures": [
-                                "add(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         },
                         "count": {
                             "name": "count",
                             "override-signatures": [
-                                "count(key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "count(key?: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         },
                         "delete": {
                             "name": "delete",
                             "override-signatures": [
-                                "delete(key: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "delete(key: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         },
                         "put": {
                             "name": "put",
                             "override-signatures": [
-                                "put(value: any, key?: IDBKeyRange | number | string | Date | IDBArrayKey): IDBRequest"
+                                "put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest"
                             ]
                         }
                     }


### PR DESCRIPTION
Fixes #426, closes #427 

IDBValidKey and IDBArrayKey is not defined in IDL, so this PR manually updates and uses them as [the spec says](https://www.w3.org/TR/IndexedDB-2/#key-construct):

>The following ECMAScript types are valid keys:
>
>* Number primitive values, except NaN. This includes Infinity and -Infinity.
>* Date objects, except where the [[DateValue]] internal slot is NaN.
>* String primitive values.
>* ArrayBuffer objects (or views on buffers such as Uint8Array).
>* Array objects, where every item is defined, is itself a valid key, and does not directly or indirectly contain itself. This includes empty arrays. Arrays can contain other arrays.
>
>Attempting to convert other ECMAScript values to a key will fail.