### PR TITLE
Support LegacyWindowAlias

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3511,6 +3511,12 @@ declare var DOMMatrix: {
     fromMatrix(other?: DOMMatrixInit): DOMMatrix;
 };
 
+type SVGMatrix = DOMMatrix;
+declare var SVGMatrix: typeof DOMMatrix;
+
+type WebKitCSSMatrix = DOMMatrix;
+declare var WebKitCSSMatrix: typeof DOMMatrix;
+
 interface DOMMatrixReadOnly {
     readonly a: number;
     readonly b: number;
@@ -3584,6 +3590,9 @@ declare var DOMPoint: {
     fromPoint(other?: DOMPointInit): DOMPoint;
 };
 
+type SVGPoint = DOMPoint;
+declare var SVGPoint: typeof DOMPoint;
+
 interface DOMPointReadOnly {
     readonly w: number;
     readonly x: number;
@@ -3627,6 +3636,9 @@ declare var DOMRect: {
     new(x?: number, y?: number, width?: number, height?: number): DOMRect;
     fromRect(other?: DOMRectInit): DOMRect;
 };
+
+type SVGRect = DOMRect;
+declare var SVGRect: typeof DOMRect;
 
 interface DOMRectList {
     readonly length: number;
@@ -12318,31 +12330,6 @@ declare var SVGMaskElement: {
     new(): SVGMaskElement;
 };
 
-interface SVGMatrix {
-    a: number;
-    b: number;
-    c: number;
-    d: number;
-    e: number;
-    f: number;
-    flipX(): SVGMatrix;
-    flipY(): SVGMatrix;
-    inverse(): SVGMatrix;
-    multiply(secondMatrix: SVGMatrix): SVGMatrix;
-    rotate(angle: number): SVGMatrix;
-    rotateFromVector(x: number, y: number): SVGMatrix;
-    scale(scaleFactor: number): SVGMatrix;
-    scaleNonUniform(scaleFactorX: number, scaleFactorY: number): SVGMatrix;
-    skewX(angle: number): SVGMatrix;
-    skewY(angle: number): SVGMatrix;
-    translate(x: number, y: number): SVGMatrix;
-}
-
-declare var SVGMatrix: {
-    prototype: SVGMatrix;
-    new(): SVGMatrix;
-};
-
 interface SVGMetadataElement extends SVGElement {
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGMetadataElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -12731,17 +12718,6 @@ declare var SVGPatternElement: {
     new(): SVGPatternElement;
 };
 
-interface SVGPoint {
-    x: number;
-    y: number;
-    matrixTransform(matrix: SVGMatrix): SVGPoint;
-}
-
-declare var SVGPoint: {
-    prototype: SVGPoint;
-    new(): SVGPoint;
-};
-
 interface SVGPointList {
     readonly numberOfItems: number;
     appendItem(newItem: SVGPoint): SVGPoint;
@@ -12835,18 +12811,6 @@ interface SVGRadialGradientElement extends SVGGradientElement {
 declare var SVGRadialGradientElement: {
     prototype: SVGRadialGradientElement;
     new(): SVGRadialGradientElement;
-};
-
-interface SVGRect {
-    height: number;
-    width: number;
-    x: number;
-    y: number;
-}
-
-declare var SVGRect: {
-    prototype: SVGRect;
-    new(): SVGRect;
 };
 
 interface SVGRectElement extends SVGGraphicsElement {
@@ -15296,46 +15260,6 @@ declare var WebGLUniformLocation: {
 
 interface WebGLVertexArrayObjectOES {
 }
-
-interface WebKitCSSMatrix {
-    a: number;
-    b: number;
-    c: number;
-    d: number;
-    e: number;
-    f: number;
-    m11: number;
-    m12: number;
-    m13: number;
-    m14: number;
-    m21: number;
-    m22: number;
-    m23: number;
-    m24: number;
-    m31: number;
-    m32: number;
-    m33: number;
-    m34: number;
-    m41: number;
-    m42: number;
-    m43: number;
-    m44: number;
-    inverse(): WebKitCSSMatrix;
-    multiply(secondMatrix: WebKitCSSMatrix): WebKitCSSMatrix;
-    rotate(angleX: number, angleY?: number, angleZ?: number): WebKitCSSMatrix;
-    rotateAxisAngle(x: number, y: number, z: number, angle: number): WebKitCSSMatrix;
-    scale(scaleX: number, scaleY?: number, scaleZ?: number): WebKitCSSMatrix;
-    setMatrixValue(value: string): void;
-    skewX(angle: number): WebKitCSSMatrix;
-    skewY(angle: number): WebKitCSSMatrix;
-    toString(): string;
-    translate(x: number, y: number, z?: number): WebKitCSSMatrix;
-}
-
-declare var WebKitCSSMatrix: {
-    prototype: WebKitCSSMatrix;
-    new(text?: string): WebKitCSSMatrix;
-};
 
 interface WebKitDirectoryEntry extends WebKitEntry {
     createReader(): WebKitDirectoryReader;

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -37,6 +37,10 @@
                     }
                 }
             },
+            "SVGMatrix": null,
+            "SVGPoint": null,
+            "SVGRect": null,
+            "WebKitCSSMatrix": null,
             "Window": {
                 "properties": {
                     "property": {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -1,12 +1,12 @@
 {
     "callback-functions": {
         "callback-function": {
-            "Function": {}
+            "Function": null
         }
     },
     "mixins": {
         "mixin": {
-            "XMLHttpRequestEventTarget": {}
+            "XMLHttpRequestEventTarget": null
         }
     },
     "callback-interfaces": {
@@ -14,8 +14,8 @@
     },
     "enums": {
         "enum": {
-            "ClientType": {},
-            "RequestType": {}
+            "ClientType": null,
+            "RequestType": null
         }
     },
     "interfaces": {
@@ -23,24 +23,24 @@
             "HTMLElement": {
                 "methods": {
                     "method": {
-                        "scrollIntoView": {},
-                        "insertAdjacentElement": {},
-                        "insertAdjacentHTML": {},
-                        "insertAdjacentText": {}
+                        "scrollIntoView": null,
+                        "insertAdjacentElement": null,
+                        "insertAdjacentHTML": null,
+                        "insertAdjacentText": null
                     }
                 }
             },
             "StorageEvent": {
                 "methods": {
                     "method": {
-                        "initStorageEvent": {}
+                        "initStorageEvent": null
                     }
                 }
             },
             "Window": {
                 "properties": {
                     "property": {
-                        "browser": {}
+                        "browser": null
                     }
                 }
             }
@@ -51,14 +51,14 @@
             "RTCRtpContributingSource": {
                 "members": {
                     "member": {
-                        "csrc": {}
+                        "csrc": null
                     }
                 }
             },
             "MediaTrackConstraintSet": {
                 "members": {
                     "member": {
-                        "echoCancelation": {}
+                        "echoCancelation": null
                     }
                 }
             }

--- a/src/index.ts
+++ b/src/index.ts
@@ -107,43 +107,30 @@ function emitDom() {
     function prune(obj: Browser.WebIdl, template: Partial<Browser.WebIdl>): Browser.WebIdl {
         const result = getEmptyWebIDL();
 
-        if (obj["callback-functions"]) result["callback-functions"]!["callback-function"] = filterProperties(obj["callback-functions"]!["callback-function"], (cb) => !(template["callback-functions"] && template["callback-functions"]!["callback-function"][cb.name]));
-        if (obj["callback-interfaces"]) result["callback-interfaces"]!.interface = filterInterface(obj["callback-interfaces"]!.interface, template["callback-interfaces"] && template["callback-interfaces"]!.interface);
-        if (obj.dictionaries) result.dictionaries!.dictionary = filterDictionary(obj.dictionaries.dictionary, template.dictionaries && template.dictionaries.dictionary);
-        if (obj.enums) result.enums!.enum = filterEnum(obj.enums.enum, template.enums && template.enums.enum);
-        if (obj.mixins) result.mixins!.mixin = filterProperties(obj.mixins.mixin, mixin => !(template.mixins && template.mixins!.mixin[mixin.name]));
-        if (obj.interfaces) result.interfaces!.interface = filterInterface(obj.interfaces.interface, template.interfaces && template.interfaces.interface);
+        if (obj["callback-functions"]) result["callback-functions"]!["callback-function"] = filterByNull(obj["callback-functions"]!["callback-function"], template["callback-functions"]!["callback-function"]);
+        if (obj["callback-interfaces"]) result["callback-interfaces"]!.interface = filterByNull(obj["callback-interfaces"]!.interface, template["callback-interfaces"]!.interface);
+        if (obj.dictionaries) result.dictionaries!.dictionary = filterByNull(obj.dictionaries.dictionary, template.dictionaries!.dictionary);
+        if (obj.enums) result.enums!.enum = filterByNull(obj.enums.enum, template.enums!.enum);
+        if (obj.mixins) result.mixins!.mixin = filterByNull(obj.mixins.mixin, template.mixins!.mixin);
+        if (obj.interfaces) result.interfaces!.interface = filterByNull(obj.interfaces.interface, template.interfaces!.interface);
         if (obj.typedefs) result.typedefs!.typedef = obj.typedefs.typedef.filter(t => !(template.typedefs && template.typedefs.typedef.find(o => o["new-type"] === t["new-type"])));
 
         return result;
 
-        function filterInterface(interfaces: Record<string, Browser.Interface>, template: Record<string, Browser.Interface> | undefined) {
-            if (!template) return interfaces;
-            const result = interfaces;
-            for (const k in result) {
-                if (result[k].properties) {
-                    result[k].properties!.property = filterProperties(interfaces[k].properties!.property, p => !(template[k] && template[k].properties && template[k].properties!.property[p.name]));
+        function filterByNull(obj: any, template: any) {
+            if (!template) return obj;
+            const filtered: any = {};
+            for (const k in obj) {
+                if (k in template) {
+                    if (template[k] !== null) {
+                        filtered[k] = filterByNull(obj[k], template[k]);
+                    }
                 }
-                if (result[k].methods) {
-                    result[k].methods!.method = filterProperties(interfaces[k].methods!.method, m => !(template[k] && template[k].methods && template[k].methods!.method[m.name]));
-                }
-            }
-            return result;
-        }
-
-        function filterDictionary(dictinaries: Record<string, Browser.Dictionary>, template: Record<string, Browser.Dictionary> | undefined) {
-            if (!template) return dictinaries;
-            const result = dictinaries;
-            for (const k in result) {
-                if (result[k].members) {
-                    result[k].members!.member = filterProperties(dictinaries[k].members!.member, m => !(template[k] && template[k].members && template[k].members!.member[m.name]));
+                else {
+                    filtered[k] = obj[k];
                 }
             }
-            return result;
-        }
-        function filterEnum(enums: Record<string, Browser.Enum>, template: Record<string, Browser.Enum> | undefined) {
-            if (!template) return enums;
-            return filterProperties(enums, i => !template[i.name]);
+            return filtered;
         }
     }
 }

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -173,6 +173,7 @@ export interface Interface {
     specs?: string;
     iterable?: "value" | "pair" | "pair-iterator";
     iterator?: Iterator;
+    "legacy-window-alias"?: string[];
 }
 
 export interface Iterator {

--- a/src/widlprocess.ts
+++ b/src/widlprocess.ts
@@ -66,6 +66,14 @@ function hasExtAttr(extAttrs: webidl2.ExtendedAttributes[], name: string) {
     return extAttrs.some(extAttr => extAttr.name === name);
 }
 
+function getExtAttr(extAttrs: webidl2.ExtendedAttributes[], name: string) {
+    const attr = extAttrs.find(extAttr => extAttr.name === name);
+    if (!attr || !attr.rhs) {
+        return;
+    }
+    return attr.rhs.type === "identifier-list" ? attr.rhs.value : [attr.rhs.value];
+}
+
 function convertInterface(i: webidl2.InterfaceType) {
     const result = convertInterfaceCommon(i);
     if (i.inheritance) {
@@ -89,7 +97,8 @@ function convertInterfaceCommon(i: webidl2.InterfaceType | webidl2.InterfaceMixi
         properties: { property: {} },
         constructor: getConstructor(i.extAttrs, i.name),
         exposed: getExposure(i.extAttrs),
-        "no-interface-object": hasExtAttr(i.extAttrs, "NoInterfaceObject") ? 1 : undefined
+        "no-interface-object": hasExtAttr(i.extAttrs, "NoInterfaceObject") ? 1 : undefined,
+        "legacy-window-alias": getExtAttr(i.extAttrs, "LegacyWindowAlias")
     };
     for (const member of i.members) {
         if (member.type === "const") {


### PR DESCRIPTION
[Geometry Interfaces Module](https://drafts.fxtf.org/geometry/) (#421) defines older SVGMatrix, WebKitCSSMatrix, etc. as legacy aliases of DOM-prefixed interfaces by `[LegacyWindowAlias]`.

This PR reads it and emits corresponding aliases, and then removes older type definitions.