### PR TITLE
Add Console types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19094,7 +19094,7 @@ declare namespace console {
     function count(label?: string): void;
     function countReset(label?: string): void;
     function debug(...data: any[]): void;
-    function dir(item: any, options?: any): void;
+    function dir(item?: any, options?: any): void;
     function dirxml(...data: any[]): void;
     function error(...data: any[]): void;
     function exception(message?: string, ...optionalParams: any[]): void;
@@ -19103,7 +19103,7 @@ declare namespace console {
     function groupEnd(): void;
     function info(...data: any[]): void;
     function log(...data: any[]): void;
-    function table(tabularData: any, properties?: string[]): void;
+    function table(tabularData?: any, properties?: string[]): void;
     function time(label?: string): void;
     function timeEnd(label?: string): void;
     function timeLog(label?: string, ...data: any[]): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3723,40 +3723,6 @@ interface ConcatParams extends Algorithm {
     publicInfo?: Uint8Array;
 }
 
-/** Provides access to the browser's debugging console (e.g. the Web Console in Firefox). The specifics of how it works varies from browser to browser, but there is a de facto set of features that are typically provided. */
-interface Console {
-    memory: any;
-    assert(condition?: boolean, message?: string, ...data: any[]): void;
-    clear(): void;
-    count(label?: string): void;
-    debug(message?: any, ...optionalParams: any[]): void;
-    dir(value?: any, ...optionalParams: any[]): void;
-    dirxml(value: any): void;
-    error(message?: any, ...optionalParams: any[]): void;
-    exception(message?: string, ...optionalParams: any[]): void;
-    group(groupTitle?: string, ...optionalParams: any[]): void;
-    groupCollapsed(groupTitle?: string, ...optionalParams: any[]): void;
-    groupEnd(): void;
-    info(message?: any, ...optionalParams: any[]): void;
-    log(message?: any, ...optionalParams: any[]): void;
-    markTimeline(label?: string): void;
-    profile(reportName?: string): void;
-    profileEnd(reportName?: string): void;
-    table(...tabularData: any[]): void;
-    time(label?: string): void;
-    timeEnd(label?: string): void;
-    timeStamp(label?: string): void;
-    timeline(label?: string): void;
-    timelineEnd(label?: string): void;
-    trace(message?: any, ...optionalParams: any[]): void;
-    warn(message?: any, ...optionalParams: any[]): void;
-}
-
-declare var Console: {
-    prototype: Console;
-    new(): Console;
-};
-
 interface ConstantSourceNode extends AudioScheduledSourceNode {
     readonly offset: AudioParam;
     addEventListener<K extends keyof AudioScheduledSourceNodeEventMap>(type: K, listener: (this: ConstantSourceNode, ev: AudioScheduledSourceNodeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -18590,7 +18556,7 @@ interface WindowEventMap extends GlobalEventHandlersEventMap, WindowEventHandler
 }
 
 /** A window containing a DOM document; the document property points to the DOM document loaded in that window. */
-interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandlers, WindowConsole, WindowEventHandlers, WindowLocalStorage, WindowOrWorkerGlobalScope, WindowSessionStorage {
+interface Window extends EventTarget, AnimationFrameProvider, GlobalEventHandlers, WindowEventHandlers, WindowLocalStorage, WindowOrWorkerGlobalScope, WindowSessionStorage {
     readonly applicationCache: ApplicationCache;
     readonly clientInformation: Navigator;
     readonly closed: boolean;
@@ -18720,10 +18686,6 @@ declare var Window: {
     prototype: Window;
     new(): Window;
 };
-
-interface WindowConsole {
-    readonly console: Console;
-}
 
 interface WindowEventHandlersEventMap {
     "afterprint": Event;
@@ -19124,6 +19086,31 @@ declare var webkitRTCPeerConnection: {
 };
 
 declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
+
+declare namespace console {
+    var memory: any;
+    function assert(condition?: boolean, ...data: any[]): void;
+    function clear(): void;
+    function count(label?: string): void;
+    function countReset(label?: string): void;
+    function debug(...data: any[]): void;
+    function dir(item: any, options?: any): void;
+    function dirxml(...data: any[]): void;
+    function error(...data: any[]): void;
+    function exception(message?: string, ...optionalParams: any[]): void;
+    function group(...data: any[]): void;
+    function groupCollapsed(...data: any[]): void;
+    function groupEnd(): void;
+    function info(...data: any[]): void;
+    function log(...data: any[]): void;
+    function table(tabularData: any, properties?: string[]): void;
+    function time(label?: string): void;
+    function timeEnd(label?: string): void;
+    function timeLog(label?: string, ...data: any[]): void;
+    function timeStamp(label?: string): void;
+    function trace(...data: any[]): void;
+    function warn(...data: any[]): void;
+}
 
 declare namespace WebAssembly {
     interface CompileError {
@@ -19706,7 +19693,6 @@ declare function toString(): string;
 declare function dispatchEvent(event: Event): boolean;
 declare var sessionStorage: Storage;
 declare var localStorage: Storage;
-declare var console: Console;
 /**
  * Fires when the user aborts the download.
  * @param ev The event.

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -924,40 +924,6 @@ interface ConcatParams extends Algorithm {
     publicInfo?: Uint8Array;
 }
 
-/** Provides access to the browser's debugging console (e.g. the Web Console in Firefox). The specifics of how it works varies from browser to browser, but there is a de facto set of features that are typically provided. */
-interface Console {
-    memory: any;
-    assert(condition?: boolean, message?: string, ...data: any[]): void;
-    clear(): void;
-    count(label?: string): void;
-    debug(message?: any, ...optionalParams: any[]): void;
-    dir(value?: any, ...optionalParams: any[]): void;
-    dirxml(value: any): void;
-    error(message?: any, ...optionalParams: any[]): void;
-    exception(message?: string, ...optionalParams: any[]): void;
-    group(groupTitle?: string, ...optionalParams: any[]): void;
-    groupCollapsed(groupTitle?: string, ...optionalParams: any[]): void;
-    groupEnd(): void;
-    info(message?: any, ...optionalParams: any[]): void;
-    log(message?: any, ...optionalParams: any[]): void;
-    markTimeline(label?: string): void;
-    profile(reportName?: string): void;
-    profileEnd(reportName?: string): void;
-    table(...tabularData: any[]): void;
-    time(label?: string): void;
-    timeEnd(label?: string): void;
-    timeStamp(label?: string): void;
-    timeline(label?: string): void;
-    timelineEnd(label?: string): void;
-    trace(message?: any, ...optionalParams: any[]): void;
-    warn(message?: any, ...optionalParams: any[]): void;
-}
-
-declare var Console: {
-    prototype: Console;
-    new(): Console;
-};
-
 /** This Streams API interface provides a built-in byte length queuing strategy that can be used when constructing streams. */
 interface CountQueuingStrategy extends QueuingStrategy {
     highWaterMark: number;
@@ -5361,10 +5327,6 @@ declare var WindowClient: {
     new(): WindowClient;
 };
 
-interface WindowConsole {
-    readonly console: Console;
-}
-
 interface WindowOrWorkerGlobalScope {
     readonly caches: CacheStorage;
     readonly crypto: Crypto;
@@ -5409,7 +5371,7 @@ interface WorkerGlobalScopeEventMap {
 }
 
 /** This Web Workers API interface is an interface representing the scope of any worker. Workers have no browsing context; this scope contains the information usually conveyed by Window objects — in this case event handlers, the console or the associated WorkerNavigator object. Each WorkerGlobalScope has its own event loop. */
-interface WorkerGlobalScope extends EventTarget, WindowConsole, WindowOrWorkerGlobalScope, WorkerUtils {
+interface WorkerGlobalScope extends EventTarget, WindowOrWorkerGlobalScope, WorkerUtils {
     readonly caches: CacheStorage;
     readonly isSecureContext: boolean;
     readonly location: WorkerLocation;
@@ -5646,6 +5608,31 @@ declare var XMLHttpRequestUpload: {
 
 declare type EventListenerOrEventListenerObject = EventListener | EventListenerObject;
 
+declare namespace console {
+    var memory: any;
+    function assert(condition?: boolean, ...data: any[]): void;
+    function clear(): void;
+    function count(label?: string): void;
+    function countReset(label?: string): void;
+    function debug(...data: any[]): void;
+    function dir(item: any, options?: any): void;
+    function dirxml(...data: any[]): void;
+    function error(...data: any[]): void;
+    function exception(message?: string, ...optionalParams: any[]): void;
+    function group(...data: any[]): void;
+    function groupCollapsed(...data: any[]): void;
+    function groupEnd(): void;
+    function info(...data: any[]): void;
+    function log(...data: any[]): void;
+    function table(tabularData: any, properties?: string[]): void;
+    function time(label?: string): void;
+    function timeEnd(label?: string): void;
+    function timeLog(label?: string, ...data: any[]): void;
+    function timeStamp(label?: string): void;
+    function trace(...data: any[]): void;
+    function warn(...data: any[]): void;
+}
+
 declare namespace WebAssembly {
     interface Global {
         value: any;
@@ -5828,7 +5815,6 @@ declare var navigator: WorkerNavigator;
 declare function importScripts(...urls: string[]): void;
 declare function atob(encodedString: string): string;
 declare function btoa(rawString: string): string;
-declare var console: Console;
 declare var caches: CacheStorage;
 declare var crypto: Crypto;
 declare var indexedDB: IDBFactory;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5615,7 +5615,7 @@ declare namespace console {
     function count(label?: string): void;
     function countReset(label?: string): void;
     function debug(...data: any[]): void;
-    function dir(item: any, options?: any): void;
+    function dir(item?: any, options?: any): void;
     function dirxml(...data: any[]): void;
     function error(...data: any[]): void;
     function exception(message?: string, ...optionalParams: any[]): void;
@@ -5624,7 +5624,7 @@ declare namespace console {
     function groupEnd(): void;
     function info(...data: any[]): void;
     function log(...data: any[]): void;
-    function table(tabularData: any, properties?: string[]): void;
+    function table(tabularData?: any, properties?: string[]): void;
     function time(label?: string): void;
     function timeEnd(label?: string): void;
     function timeLog(label?: string, ...data: any[]): void;

--- a/inputfiles/idl/Console.widl
+++ b/inputfiles/idl/Console.widl
@@ -1,0 +1,29 @@
+[Exposed=(Window,Worker,Worklet)]
+namespace console { // but see namespace object requirements below
+  // Logging
+  void assert(optional boolean condition = false, any... data);
+  void clear();
+  void debug(any... data);
+  void error(any... data);
+  void info(any... data);
+  void log(any... data);
+  void table(any tabularData, optional sequence<DOMString> properties);
+  void trace(any... data);
+  void warn(any... data);
+  void dir(any item, optional object? options);
+  void dirxml(any... data);
+
+  // Counting
+  void count(optional DOMString label = "default");
+  void countReset(optional DOMString label = "default");
+
+  // Grouping
+  void group(any... data);
+  void groupCollapsed(any... data);
+  void groupEnd();
+
+  // Timing
+  void time(optional DOMString label = "default");
+  void timeLog(optional DOMString label = "default", any... data);
+  void timeEnd(optional DOMString label = "default");
+};

--- a/inputfiles/idl/Console.widl
+++ b/inputfiles/idl/Console.widl
@@ -7,10 +7,10 @@ namespace console { // but see namespace object requirements below
   void error(any... data);
   void info(any... data);
   void log(any... data);
-  void table(any tabularData, optional sequence<DOMString> properties);
+  void table(optional any tabularData, optional sequence<DOMString> properties);
   void trace(any... data);
   void warn(any... data);
-  void dir(any item, optional object? options);
+  void dir(optional any item, optional object? options);
   void dirxml(any... data);
 
   // Counting

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -9,6 +9,10 @@
         "deprecated": true
     },
     {
+        "url": "https://console.spec.whatwg.org/",
+        "title": "Console"
+    },
+    {
         "url": "https://www.w3.org/TR/credential-management-1/",
         "title": "Credential Management"
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -994,79 +994,6 @@
                     }
                 }
             },
-            "Console": {
-                "name": "Console",
-                "methods": {
-                    "method": {
-                        "debug": {
-                            "name": "debug",
-                            "override-signatures": [
-                                "debug(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "dir": {
-                            "name": "dir",
-                            "override-signatures": [
-                                "dir(value?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "dirxml": {
-                            "name": "dirxml",
-                            "override-signatures": [
-                                "dirxml(value: any): void"
-                            ]
-                        },
-                        "error": {
-                            "name": "error",
-                            "override-signatures": [
-                                "error(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "info": {
-                            "name": "info",
-                            "override-signatures": [
-                                "info(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "log": {
-                            "name": "log",
-                            "override-signatures": [
-                                "log(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "warn": {
-                            "name": "warn",
-                            "override-signatures": [
-                                "warn(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "group": {
-                            "name": "group",
-                            "override-signatures": [
-                                "group(groupTitle?: string, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "groupCollapsed": {
-                            "name": "groupCollapsed",
-                            "override-signatures": [
-                                "groupCollapsed(groupTitle?: string, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "trace": {
-                            "name": "trace",
-                            "override-signatures": [
-                                "trace(message?: any, ...optionalParams: any[]): void"
-                            ]
-                        },
-                        "profileEnd": {
-                            "name": "profileEnd",
-                            "override-signatures": [
-                                "profileEnd(reportName?: string): void"
-                            ]
-                        }
-                    }
-                }
-            },
             "FormData": {
                 "name": "FormData",
                 "methods": {
@@ -3237,6 +3164,33 @@
         ]
     },
     "namespaces": [
+        {
+            "name": "console",
+            "methods": {
+                "method": {
+                    "exception": {
+                        "name": "exception",
+                        "override-signatures": [
+                            "exception(message?: string, ...optionalParams: any[]): void"
+                        ]
+                    },
+                    "timeStamp": {
+                        "name": "timeStamp",
+                        "override-signatures": [
+                            "timeStamp(label?: string): void"
+                        ]
+                    }
+                }
+            },
+            "properties": {
+                "property": {
+                    "memory": {
+                        "name": "memory",
+                        "type": "any"
+                    }
+                }
+            }
+        },
         {
             "name": "WebAssembly",
             "methods": {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -68,14 +68,7 @@
                 }
             },
             "ClipboardItem": null,
-            "Console": {
-                "methods": {
-                    "method": {
-                        "msIsIndependentlyComposed": null,
-                        "select": null
-                    }
-                }
-            },
+            "Console": null,
             "CSSStyleDeclaration": {
                 "properties": {
                     "property": {
@@ -321,12 +314,14 @@
                     "GlobalFetch",
                     "IDBEnvironment",
                     "WindowBase64",
-                    "WindowTimers"
+                    "WindowTimers",
+                    "WindowConsole"
                 ]
             },
             "WorkerGlobalScope": {
                 "implements": [
-                    "GlobalFetch"
+                    "GlobalFetch",
+                    "WindowConsole"
                 ]
             },
             "XPathNSResolver": null


### PR DESCRIPTION
This introduces namespace types.

This removes:

* ~~`.memory`~~ (It exists on Chrome so keeping for compatibility)
* ~~`.exception()`~~ (It exists on Firefox so keeping for compatibility)
* `.markTimeline()`
* `.profile()` (It exists on Firefox and Chrome but is non-functional https://github.com/whatwg/console/issues/144#issuecomment-432184849)
* `.profileEnd()`
* ~~`.timeStamp()`~~ (Not specced yet but is widely implemented https://github.com/whatwg/console/issues/140)
* `.timeline()`
* `.timelineEnd()`

and adds:

* `.countReset()`
* `.timeLog()`