### PR TITLE
Emit iterator for iterable/maplike/setlike

### DIFF
--- a/baselines/dom.es6.generated.d.ts
+++ b/baselines/dom.es6.generated.d.ts
@@ -38,12 +38,26 @@ interface FileList {
     [Symbol.iterator](): IterableIterator<File>
 }
 
+interface FormData {
+    [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>
+    entries(): IterableIterator<[string, FormDataEntryValue]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<FormDataEntryValue>;
+}
+
 interface HTMLAllCollection {
     [Symbol.iterator](): IterableIterator<Element>
 }
 
 interface HTMLCollection {
     [Symbol.iterator](): IterableIterator<Element>
+}
+
+interface Headers {
+    [Symbol.iterator](): IterableIterator<[string, string]>
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
 }
 
 interface MediaList {
@@ -70,6 +84,9 @@ interface PluginArray {
     [Symbol.iterator](): IterableIterator<Plugin>
 }
 
+interface RTCStatsReport extends ReadonlyMap<string, any> {
+}
+
 interface SourceBufferList {
     [Symbol.iterator](): IterableIterator<SourceBuffer>
 }
@@ -88,6 +105,13 @@ interface TextTrackList {
 
 interface TouchList {
     [Symbol.iterator](): IterableIterator<Touch>
+}
+
+interface URLSearchParams {
+    [Symbol.iterator](): IterableIterator<[string, string]>
+    entries(): IterableIterator<[string, string]>;
+    keys(): IterableIterator<string>;
+    values(): IterableIterator<string>;
 }
 
 interface VideoTrackList {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -11097,6 +11097,7 @@ declare var RTCStatsProvider: {
 };
 
 interface RTCStatsReport {
+    forEach(callbackfn: (value: any, key: string, parent: RTCStatsReport) => void, thisArg?: any): void;
 }
 
 declare var RTCStatsReport: {

--- a/src/widlprocess.ts
+++ b/src/widlprocess.ts
@@ -120,7 +120,7 @@ function convertInterfaceCommon(i: webidl2.InterfaceType | webidl2.InterfaceMixi
                 method[member.name] = operation;
             }
         }
-        else if (member.type === "iterable") {
+        else if (member.type === "iterable" || member.type === "maplike" || member.type === "setlike") {
             result.iterator = {
                 type: member.type,
                 readonly: member.readonly,


### PR DESCRIPTION
This emits iterators for interfaces with `iterable<>`, `maplike<>`, `setlike<>` declarations.