### PR TITLE
Remove redundant iterator methods from HTMLCollectionOf

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5919,9 +5919,8 @@ declare var HTMLCollection: {
 };
 
 interface HTMLCollectionOf<T extends Element> extends HTMLCollectionBase {
-    item(index: number): T;
-    namedItem(name: string): T;
-    forEach(callbackfn: (value: T, key: number, parent: HTMLCollectionOf<T>) => void, thisArg?: any): void;
+    item(index: number): T | null;
+    namedItem(name: string): T | null;
     [index: number]: T;
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5902,7 +5902,7 @@ interface HTMLCollectionBase {
     /**
      * Retrieves an object from various collections.
      */
-    item(index: number): Element;
+    item(index: number): Element | null;
     [index: number]: Element;
 }
 

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -67,9 +67,6 @@ interface HTMLCollectionBase {
 
 interface HTMLCollectionOf<T extends Element> {
     [Symbol.iterator](): IterableIterator<T>;
-    entries(): IterableIterator<[number, T]>;
-    keys(): IterableIterator<number>;
-    values(): IterableIterator<T>;
 }
 
 interface HTMLSelectElement {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -472,29 +472,31 @@
                 "methods": {
                     "method": {
                         "item": {
-                            "name": "item",
-                            "override-signatures": [
-                                "item(index: number): T"
-                            ]
+                            "getter": 1,
+                            "signature": [
+                                {
+                                    "nullable": 1,
+                                    "override-type": "T",
+                                    "param": [
+                                        {
+                                            "name": "index",
+                                            "type": "unsigned long"
+                                        }
+                                    ]
+                                }
+                            ],
+                            "specs": "html5",
+                            "name": "item"
                         },
                         "namedItem": {
                             "name": "namedItem",
                             "override-signatures": [
-                                "namedItem(name: string): T"
+                                "namedItem(name: string): T | null"
                             ]
                         }
                     }
                 },
-                "no-interface-object": "1",
-                "override-index-signatures": [
-                    "[index: number]: T"
-                ],
-                "iterator": {
-                    "kind": "iterable",
-                    "type": [{
-                        "override-type": "T"
-                    }]
-                }
+                "no-interface-object": "1"
             },
             "EventListenerObject": {
                 "name": "EventListenerObject",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -511,19 +511,6 @@
                     }
                 }
             },
-            "HTMLCollection": {
-                "name": "HTMLCollection",
-                "methods": {
-                    "method": {
-                        "item": {
-                            "name": "item",
-                            "override-signatures": [
-                                "item(index: number): Element"
-                            ]
-                        }
-                    }
-                }
-            },
             "IDBObjectStore": {
                 "name": "IDBObjectStore",
                 "methods": {


### PR DESCRIPTION
...and only keep `[Symbol.iterator](): IterableIterator<T>`.
