### PR TITLE
Fixed #24119 - Removed @deprecated for disabled in HTMLLinkElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7058,7 +7058,6 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
     /** @deprecated */
     charset: string;
     crossOrigin: string | null;
-    /** @deprecated */
     disabled: boolean;
     /**
      * Sets or retrieves a destination URL or an anchor point.

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -239,6 +239,11 @@
                 "name": "HTMLLinkElement",
                 "properties": {
                     "property": {
+                        "disabled":{
+                            "deprecated": 0,
+                            "name": "disabled",
+                            "type": "boolean"
+                        },
                         "relList": {
                             "read-only": 1,
                             "name": "relList",


### PR DESCRIPTION
This PR fixes https://github.com/Microsoft/TypeScript/issues/24119.

It removes the `@deprecated` from `disabled` in `HTMLLinkElement`.

Thanks for considering this request.