### PR TITLE
Add exposure module

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1006,7 +1006,7 @@ interface MessageEventInit extends EventInit {
     lastEventId?: string;
     origin?: string;
     ports?: MessagePort[];
-    source?: Window | null;
+    source?: MessageEventSource | null;
 }
 
 interface MouseEventInit extends EventModifierInit {
@@ -3393,10 +3393,8 @@ interface Console {
     info(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
     markTimeline(label?: string): void;
-    msIsIndependentlyComposed(element: Element): boolean;
     profile(reportName?: string): void;
     profileEnd(): void;
-    select(element: Element): void;
     table(...tabularData: any[]): void;
     time(label?: string): void;
     timeEnd(label?: string): void;
@@ -5173,7 +5171,6 @@ interface Event {
     readonly eventPhase: number;
     readonly isTrusted: boolean;
     returnValue: boolean;
-    readonly srcElement: Element | null;
     readonly target: EventTarget | null;
     readonly timeStamp: number;
     readonly type: string;
@@ -9997,7 +9994,6 @@ interface MessageEvent extends Event {
     readonly origin: string;
     readonly ports: ReadonlyArray<MessagePort>;
     readonly source: MessageEventSource;
-    initMessageEvent(type: string, bubbles: boolean, cancelable: boolean, data: any, origin: string, lastEventId: string, source: Window): void;
 }
 
 declare var MessageEvent: {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2472,7 +2472,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
      * Initiates the request. The optional argument provides the request body. The argument is ignored if request method is GET or HEAD.
      * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.
      */
-    send(body?: BodyInit): void;
+    send(body?: BodyInit | null): void;
     /**
      * Combines a header in author request headers.
      * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -153,7 +153,7 @@ interface MessageEventInit extends EventInit {
     lastEventId?: string;
     origin?: string;
     ports?: MessagePort[];
-    source?: object | null;
+    source?: MessageEventSource | null;
 }
 
 interface NavigationPreloadState {
@@ -243,7 +243,7 @@ interface RequestInit {
     redirect?: RequestRedirect;
     referrer?: string;
     referrerPolicy?: ReferrerPolicy;
-    signal?: object | null;
+    signal?: AbortSignal | null;
     window?: any;
 }
 
@@ -275,6 +275,24 @@ interface TextDecoderOptions {
 interface EventListener {
     (evt: Event): void;
 }
+
+interface AbortSignalEventMap {
+    "abort": ProgressEvent;
+}
+
+interface AbortSignal extends EventTarget {
+    readonly aborted: boolean;
+    onabort: ((this: AbortSignal, ev: ProgressEvent) => any) | null;
+    addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
+    removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+declare var AbortSignal: {
+    prototype: AbortSignal;
+    new(): AbortSignal;
+};
 
 interface AbstractWorkerEventMap {
     "error": ErrorEvent;
@@ -443,10 +461,8 @@ interface Console {
     info(message?: any, ...optionalParams: any[]): void;
     log(message?: any, ...optionalParams: any[]): void;
     markTimeline(label?: string): void;
-    msIsIndependentlyComposed(element: object): boolean;
     profile(reportName?: string): void;
     profileEnd(): void;
-    select(element: object): void;
     table(...tabularData: any[]): void;
     time(label?: string): void;
     timeEnd(label?: string): void;
@@ -789,7 +805,6 @@ interface Event {
     readonly eventPhase: number;
     readonly isTrusted: boolean;
     returnValue: boolean;
-    readonly srcElement: object | null;
     readonly target: EventTarget | null;
     readonly timeStamp: number;
     readonly type: string;
@@ -972,7 +987,7 @@ interface FormData {
 
 declare var FormData: {
     prototype: FormData;
-    new(form?: object): FormData;
+    new(): FormData;
 };
 
 interface GlobalFetch {
@@ -1526,7 +1541,6 @@ interface MessageEvent extends Event {
     readonly origin: string;
     readonly ports: ReadonlyArray<MessagePort>;
     readonly source: MessageEventSource;
-    initMessageEvent(type: string, bubbles: boolean, cancelable: boolean, data: any, origin: string, lastEventId: string, source: object): void;
 }
 
 declare var MessageEvent: {
@@ -1948,7 +1962,7 @@ interface Request extends Body {
      * Returns the signal associated with request, which is an AbortSignal object indicating whether or not request has been aborted, and its abort
      * event handler.
      */
-    readonly signal: object;
+    readonly signal: AbortSignal;
     /**
      * Returns the URL of request as a string.
      */
@@ -2458,7 +2472,7 @@ interface XMLHttpRequest extends XMLHttpRequestEventTarget {
      * Initiates the request. The optional argument provides the request body. The argument is ignored if request method is GET or HEAD.
      * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.
      */
-    send(body?: object | BodyInit | null): void;
+    send(body?: BodyInit): void;
     /**
      * Combines a header in author request headers.
      * Throws an "InvalidStateError" DOMException if either state is not opened or the send() flag is set.
@@ -2582,7 +2596,7 @@ type BufferSource = ArrayBufferView | ArrayBuffer;
 type DOMTimeStamp = number;
 type FormDataEntryValue = File | string;
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
-type MessageEventSource = object | MessagePort | ServiceWorker;
+type MessageEventSource = MessagePort | ServiceWorker;
 type BinaryType = "blob" | "arraybuffer";
 type ClientTypes = "window" | "worker" | "sharedworker" | "all";
 type IDBCursorDirection = "next" | "nextunique" | "prev" | "prevunique";

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2229,6 +2229,10 @@
                             "name": "channel",
                             "override-type": "string",
                             "required": 0
+                        },
+                        "source": {
+                            "name": "source",
+                            "type": "MessageEventSource"
                         }
                     }
                 }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2322,6 +2322,10 @@
                     }
                 ]
             },
+            "AbortSignal": {
+                "name": "AbortSignal",
+                "override-exposed": "Window Worker"
+            },
             "CryptoKey": {
                 "name": "CryptoKey",
                 "override-exposed": "Window Worker"

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -24,6 +24,21 @@
     },
     "interfaces": {
         "interface": {
+            "Console": {
+                "methods": {
+                    "method": {
+                        "msIsIndependentlyComposed": null,
+                        "select": null
+                    }
+                }  
+            },
+            "Event": {
+                "properties": {
+                    "property": {
+                        "srcElement": null
+                    }
+                }
+            },
             "FileReaderProgressEvent": null,
             "HTMLElement": {
                 "methods": {
@@ -39,6 +54,13 @@
                 "implements": null
             },
             "MediaQueryListListener": null,
+            "MessageEvent": {
+                "methods": {
+                    "method": {
+                        "initMessageEvent": null
+                    }
+                }
+            },
             "MSStreamReader": null,
             "Screen": {
                 "methods": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -297,7 +297,6 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
             case "DOMTimeStamp": return "number";
             case "EventListener": return "EventListenerOrEventListenerObject";
         }
-        if (flavor === Flavor.Worker && (objDomType === "Element" || objDomType === "Window" || objDomType === "Document" || objDomType === "AbortSignal" || objDomType === "HTMLFormElement")) return "object";
         if (flavor === Flavor.Web && objDomType === "Client") return "object";
         // Name of an interface / enum / dict. Just return itself
         if (allInterfacesMap[objDomType] ||

--- a/src/expose.ts
+++ b/src/expose.ts
@@ -1,0 +1,156 @@
+import * as Browser from "./types";
+import { getEmptyWebIDL, filter, exposesTo, followTypeReferences, filterProperties, mapToArray } from "./helpers";
+
+export function getExposedTypes(webidl: Browser.WebIdl, target: string, forceKnownTypes: Set<string>) {
+    const unexposedTypes = new Set<string>();
+    const filtered = getEmptyWebIDL();
+    if (webidl.interfaces) {
+        filtered.interfaces!.interface = filter(webidl.interfaces.interface, o => exposesTo(o, target));
+        const unexposedInterfaces = mapToArray(webidl.interfaces.interface).filter(i => i.exposed && !i.exposed.includes(target));
+        for (const i of unexposedInterfaces) {
+            unexposedTypes.add(i.name);
+        }
+    }
+
+    const knownIDLTypes = followTypeReferences(webidl, filtered.interfaces!.interface);
+    const isKnownName = (o: { name: string }) => knownIDLTypes.has(o.name) || forceKnownTypes.has(o.name);
+
+    if (webidl.typedefs) {
+        const referenced = webidl.typedefs.typedef.filter(t => knownIDLTypes.has(t["new-type"]) || forceKnownTypes.has(t["new-type"]));
+        const { exposed, removed } = filterTypedefs(referenced, unexposedTypes);
+        removed.forEach(s => unexposedTypes.add(s));
+        filtered.typedefs!.typedef = exposed;
+    }
+
+    if (webidl["callback-functions"]) filtered["callback-functions"]!["callback-function"] = filterProperties(webidl["callback-functions"]!["callback-function"], isKnownName);
+    if (webidl["callback-interfaces"]) filtered["callback-interfaces"]!.interface = filterProperties(webidl["callback-interfaces"]!.interface, isKnownName);
+    if (webidl.dictionaries) filtered.dictionaries!.dictionary = filterProperties(webidl.dictionaries.dictionary, isKnownName);
+    if (webidl.enums) filtered.enums!.enum = filterProperties(webidl.enums.enum, isKnownName);
+    if (webidl.mixins) filtered.mixins!.mixin = filterProperties(webidl.mixins.mixin, isKnownName);
+
+    return deepFilterUnexposedTypes(filtered, unexposedTypes);
+}
+
+/**
+ * Filters unexposed types out from typedefs and
+ * removes typedefs that only contains unexposed type names
+ * @param typedefs target typedef array
+ * @param unexposedTypes type names to be filtered out
+ */
+function filterTypedefs(typedefs: Browser.TypeDef[], unexposedTypes: Set<string>): { exposed: Browser.TypeDef[], removed: Set<string> } {
+    const exposed: Browser.TypeDef[] = [];
+    const removed = new Set<string>();
+
+    typedefs.forEach(filterTypedef);
+    if (removed.size) {
+        const result = filterTypedefs(exposed, removed);
+        result.removed.forEach(s => removed.add(s));
+        return { exposed: result.exposed, removed }
+    }
+    else {
+        return { exposed, removed };
+    }
+
+    function filterTypedef(typedef: Browser.TypeDef) {
+        if (typedef["override-type"]) {
+            exposed.push(typedef);
+        }
+        else if (Array.isArray(typedef.type)) {
+            const filteredType = filterUnexposedTypeFromUnion(typedef.type, unexposedTypes);
+            if (!filteredType.length) {
+                removed.add(typedef["new-type"]);
+            }
+            else {
+                exposed.push({ ...typedef, ...typesAsMixin(filteredType) });
+            }
+        }
+        else if (unexposedTypes.has(typedef.type)) {
+            removed.add(typedef["new-type"]);
+        }
+        else {
+            exposed.push(typedef);
+        }
+    }
+}
+
+/**
+ * Filters out unexposed type names from union types and optional function arguments
+ * @param webidl target types
+ * @param unexposedTypes type names to be filtered out
+ */
+function deepFilterUnexposedTypes(webidl: Browser.WebIdl, unexposedTypes: Set<string>) {
+    return deepClone(webidl, o => {
+        if (Array.isArray(o.type)) {
+            return { ...o, type: filterUnexposedTypeFromUnion(o.type, unexposedTypes) }
+        }
+        if (Array.isArray(o.signature)) {
+            return { ...o, signature: o.signature.map(filterUnknownTypeFromSignature) };
+        }
+    });
+
+    function filterUnknownTypeFromSignature(signature: Browser.Signature) {
+        if (!signature.param) {
+            return signature;
+        }
+        const param: Browser.Param[] = [];
+        for (const p of signature.param) {
+            const types = Array.isArray(p.type) ? p.type : [p];
+            const filtered = filterUnexposedTypeFromUnion(types, unexposedTypes);
+            if (filtered.length >= 1) {
+                param.push({ ...p, ...typesAsMixin(filtered) });
+            }
+            else if (!p.optional) {
+                throw new Error("A non-optional parameter has unknown type");
+            }
+            else {
+                // safe to skip
+                break;
+            }
+        }
+        return { ...signature, param };
+    }
+}
+
+function filterUnexposedTypeFromUnion(union: Browser.Typed[], unexposedTypes: Set<string>): Browser.Typed[] {
+    const result: Browser.Typed[] = [];
+    for (const type of union) {
+        if (Array.isArray(type.type)) {
+            const filteredUnion = filterUnexposedTypeFromUnion(type.type, unexposedTypes);
+            if (filteredUnion.length) {
+                result.push({ ...type, ...typesAsMixin(filteredUnion) });
+            }
+        }
+        else if (type["override-type"] || !unexposedTypes.has(type.type)) {
+            result.push(type);
+        }
+    }
+    return result;
+}
+
+function deepClone<T>(o: T, custom: (o: any) => any): T {
+    if (!o || typeof o !== "object") {
+        return o;
+    }
+    if (Array.isArray(o)) {
+        return o.map(v => deepClone(v, custom)) as any as T;
+    }
+    const mapped = custom(o);
+    if (mapped !== undefined) {
+        return mapped;
+    }
+    const clone: any = {};
+    for (const key of Object.getOwnPropertyNames(o)) {
+        clone[key] = deepClone((o as any)[key], custom);
+    }
+    return clone;
+}
+
+function typesAsMixin(type: Browser.Typed[]) {
+    if (type.length > 1) {
+        return { type };
+    }
+    else if (type.length === 1) {
+        return type[0];
+    }
+    throw new Error("Cannot process empty union type");
+}

--- a/src/expose.ts
+++ b/src/expose.ts
@@ -61,7 +61,7 @@ function filterTypedefs(typedefs: Browser.TypeDef[], unexposedTypes: Set<string>
                 removed.add(typedef["new-type"]);
             }
             else {
-                exposed.push({ ...typedef, ...typesAsMixin(filteredType) });
+                exposed.push({ ...typedef, type: flattenType(filteredType) });
             }
         }
         else if (unexposedTypes.has(typedef.type)) {
@@ -97,7 +97,7 @@ function deepFilterUnexposedTypes(webidl: Browser.WebIdl, unexposedTypes: Set<st
             const types = Array.isArray(p.type) ? p.type : [p];
             const filtered = filterUnexposedTypeFromUnion(types, unexposedTypes);
             if (filtered.length >= 1) {
-                param.push({ ...p, ...typesAsMixin(filtered) });
+                param.push({ ...p, type: flattenType(filtered) });
             }
             else if (!p.optional) {
                 throw new Error("A non-optional parameter has unknown type");
@@ -117,7 +117,7 @@ function filterUnexposedTypeFromUnion(union: Browser.Typed[], unexposedTypes: Se
         if (Array.isArray(type.type)) {
             const filteredUnion = filterUnexposedTypeFromUnion(type.type, unexposedTypes);
             if (filteredUnion.length) {
-                result.push({ ...type, ...typesAsMixin(filteredUnion) });
+                result.push({ ...type, type: flattenType(filteredUnion) });
             }
         }
         else if (type["override-type"] || !unexposedTypes.has(type.type)) {
@@ -145,12 +145,12 @@ function deepClone<T>(o: T, custom: (o: any) => any): T {
     return clone;
 }
 
-function typesAsMixin(type: Browser.Typed[]) {
+function flattenType(type: Browser.Typed[]) {
     if (type.length > 1) {
-        return { type };
+        return type;
     }
     else if (type.length === 1) {
-        return type[0];
+        return type[0].type;
     }
     throw new Error("Cannot process empty union type");
 }

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -20,10 +20,10 @@ export const baseTypeConversionMap = new Map<string, string>([
     ["EventHandler", "EventHandler"]
 ]);
 
-export function filter(obj: any, fn: (o: any, n: string | undefined) => boolean): any {
+export function filter<T>(obj: T, fn: (o: any, n: string | undefined) => boolean): T {
     if (typeof obj === "object") {
         if (Array.isArray(obj)) {
-            return mapDefined(obj, e => fn(e, undefined) ? filter(e, fn) : undefined);
+            return mapDefined(obj, e => fn(e, undefined) ? filter(e, fn) : undefined) as any as T;
         }
         else {
             const result: any = {};


### PR DESCRIPTION
Replaces related lines from #459 

Now non-Worker exposed types are not processed as `"object"` but 1) are omitted if optional 2) throws if not.

This removes some Worker-incompatible non-standard types.