### PR TITLE
Add HTML semantics types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6556,8 +6556,6 @@ declare var HTMLHRElement: {
 };
 
 interface HTMLHeadElement extends HTMLElement {
-    /** @deprecated */
-    profile: string;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7052,13 +7050,13 @@ declare var HTMLLegendElement: {
 };
 
 interface HTMLLinkElement extends HTMLElement, LinkStyle {
+    as: string;
     /**
      * Sets or retrieves the character set used to encode the object.
      */
     /** @deprecated */
     charset: string;
     crossOrigin: string | null;
-    disabled: boolean;
     /**
      * Sets or retrieves a destination URL or an anchor point.
      */
@@ -7067,12 +7065,12 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
      * Sets or retrieves the language code of the object.
      */
     hreflang: string;
-    import?: Document;
     integrity: string;
     /**
      * Sets or retrieves the media type.
      */
     media: string;
+    referrerPolicy: string;
     /**
      * Sets or retrieves the relationship between the object and the destination of the link.
      */
@@ -7083,6 +7081,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
      */
     /** @deprecated */
     rev: string;
+    readonly sizes: DOMTokenList;
     /**
      * Sets or retrieves the window or frame at which to target content.
      */
@@ -7398,11 +7397,6 @@ declare var HTMLMenuElement: {
 
 interface HTMLMetaElement extends HTMLElement {
     /**
-     * Sets or retrieves the character set used to encode the object.
-     */
-    /** @deprecated */
-    charset: string;
-    /**
      * Gets or sets meta-information to associate with httpEquiv or name.
      */
     content: string;
@@ -7419,11 +7413,6 @@ interface HTMLMetaElement extends HTMLElement {
      */
     /** @deprecated */
     scheme: string;
-    /**
-     * Sets or retrieves the URL property that will be loaded after the specified time has elapsed.
-     */
-    /** @deprecated */
-    url: string;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMetaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMetaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8053,8 +8042,6 @@ declare var HTMLSpanElement: {
 };
 
 interface HTMLStyleElement extends HTMLElement, LinkStyle {
-    /** @deprecated */
-    disabled: boolean;
     /**
      * Sets or retrieves the media type.
      */

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7053,6 +7053,7 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
     /** @deprecated */
     charset: string;
     crossOrigin: string | null;
+    disabled: boolean;
     /**
      * Sets or retrieves a destination URL or an anchor point.
      */

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2154,6 +2154,14 @@
                 ]
             },
             "HTMLLinkElement": {
+                "properties": {
+                    "property": {
+                        "disabled":{
+                            "name": "disabled",
+                            "type": "boolean"
+                        }
+                    }
+                },
                 "element": [
                     {
                         "name": "link"

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -713,18 +713,6 @@
                     }
                 }
             },
-            "HTMLLinkElement": {
-                "name": "HTMLLinkElement",
-                "properties": {
-                    "property": {
-                        "import": {
-                            "name": "import",
-                            "override-type": "Document",
-                            "required": 0
-                        }
-                    }
-                }
-            },
             "HTMLCanvasElement": {
                 "name": "HTMLCanvasElement",
                 "methods": {
@@ -2123,6 +2111,48 @@
                 },
                 "no-interface-object": "1"
             },
+            "HTMLBaseElement": {
+                "element": [
+                    {
+                        "name": "base"
+                    }
+                ]
+            },
+            "HTMLHeadElement": {
+                "element": [
+                    {
+                        "name": "head"
+                    }
+                ]
+            },
+            "HTMLHtmlElement": {
+                "element": [
+                    {
+                        "name": "html"
+                    }
+                ]
+            },
+            "HTMLLinkElement": {
+                "element": [
+                    {
+                        "name": "link"
+                    }
+                ]
+            },
+            "HTMLMetaElement": {
+                "element": [
+                    {
+                        "name": "meta"
+                    }
+                ]
+            },
+            "HTMLStyleElement": {
+                "element": [
+                    {
+                        "name": "style"
+                    }
+                ]
+            },
             "HTMLTableDataCellElement": {
                 "name": "HTMLTableDataCellElement",
                 "extends": "HTMLTableCellElement",
@@ -2150,6 +2180,13 @@
                 "element": [
                     {
                         "name": "th"
+                    }
+                ]
+            },
+            "HTMLTitleElement": {
+                "element": [
+                    {
+                        "name": "title"
                     }
                 ]
             },

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -265,14 +265,8 @@
                         "content": {
                             "comment": "/**\r\n     * Gets or sets meta-information to associate with httpEquiv or name.\r\n     */"
                         },
-                        "url": {
-                            "comment": "/**\r\n     * Sets or retrieves the URL property that will be loaded after the specified time has elapsed.\r\n     */"
-                        },
                         "scheme": {
                             "comment": "/**\r\n     * Sets or retrieves a scheme to be used in interpreting the value of a property specified for the object.\r\n     */"
-                        },
-                        "charset": {
-                            "comment": "/**\r\n     * Sets or retrieves the character set used to encode the object.\r\n     */"
                         }
                     }
                 }

--- a/inputfiles/idl/HTML - Semantics.commentmap.json
+++ b/inputfiles/idl/HTML - Semantics.commentmap.json
@@ -1,0 +1,3 @@
+{
+    "title-text": "Returns the child text content of the element.\nCan be set, to replace the element's children with the given value."
+}

--- a/inputfiles/idl/HTML - Semantics.widl
+++ b/inputfiles/idl/HTML - Semantics.widl
@@ -1,0 +1,52 @@
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLHtmlElement : HTMLElement {};
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLHeadElement : HTMLElement {};
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLTitleElement : HTMLElement {
+  [CEReactions] attribute DOMString text;
+};
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLBaseElement : HTMLElement {
+  [CEReactions] attribute USVString href;
+  [CEReactions] attribute DOMString target;
+};
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLLinkElement : HTMLElement {
+  [CEReactions] attribute USVString href;
+  [CEReactions] attribute DOMString? crossOrigin;
+  [CEReactions] attribute DOMString rel;
+  [CEReactions] attribute DOMString as; // (default "")
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList relList;
+  [CEReactions] attribute DOMString media;
+  [CEReactions] attribute DOMString integrity;
+  [CEReactions] attribute DOMString hreflang;
+  [CEReactions] attribute DOMString type;
+  [SameObject, PutForwards=value] readonly attribute DOMTokenList sizes;
+  [CEReactions] attribute DOMString referrerPolicy;
+};
+HTMLLinkElement includes LinkStyle;
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLMetaElement : HTMLElement {
+  [CEReactions] attribute DOMString name;
+  [CEReactions] attribute DOMString httpEquiv;
+  [CEReactions] attribute DOMString content;
+};
+
+[Exposed=Window,
+ HTMLConstructor]
+interface HTMLStyleElement : HTMLElement {
+  [CEReactions] attribute DOMString media;
+};
+HTMLStyleElement includes LinkStyle;

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -49,6 +49,10 @@
         "deprecated": true
     },
     {
+        "url": "https://html.spec.whatwg.org/multipage/semantics.html",
+        "title": "HTML - Semantics"
+    },
+    {
         "url": "https://html.spec.whatwg.org/multipage/webstorage.html",
         "title": "HTML - Web storage"
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -235,23 +235,6 @@
                     }
                 }
             },
-            "HTMLLinkElement": {
-                "name": "HTMLLinkElement",
-                "properties": {
-                    "property": {
-                        "disabled":{
-                            "deprecated": 0,
-                            "name": "disabled",
-                            "type": "boolean"
-                        },
-                        "relList": {
-                            "read-only": 1,
-                            "name": "relList",
-                            "type": "DOMTokenList"
-                        }
-                    }
-                }
-            },
             "SourceBuffer": {
                 "specs": "media-source",
                 "name": "SourceBuffer",


### PR DESCRIPTION
Removes `HTMLLinkElement.import`. It was for HTML Imports but the spec hasn't been able to gather enough interest from vendors.