### PR TITLE
Fixed #19548 - Added @deprecated to className in SVGElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12038,6 +12038,7 @@ interface SVGElementEventMap extends ElementEventMap {
 }
 
 interface SVGElement extends Element, ElementCSSInlineStyle {
+    /** @deprecated */
     readonly className: any;
     onclick: ((this: SVGElement, ev: MouseEvent) => any) | null;
     ondblclick: ((this: SVGElement, ev: MouseEvent) => any) | null;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -919,6 +919,7 @@
                 "properties": {
                     "property": {
                         "className": {
+                            "deprecated": 1,
                             "name": "className",
                             "override-type": "any"
                         }


### PR DESCRIPTION
This PR addresses this issue: https://github.com/Microsoft/TypeScript/issues/19548.

It adds `@deprecated` to `className` in `SVGElement`.

Thanks for considering this PR.