### PR TITLE
Fixed #24084 - Changed HTMLSelectElement Index Signature

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7625,7 +7625,7 @@ interface HTMLSelectElement extends HTMLElement {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSelectElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    [index: number]: Element;
+    [name: string]: HTMLOptionElement | HTMLOptGroupElement;
 }
 
 declare var HTMLSelectElement: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7625,7 +7625,7 @@ interface HTMLSelectElement extends HTMLElement {
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSelectElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
-    [name: string]: HTMLOptionElement | HTMLOptGroupElement;
+    [name: number]: HTMLOptionElement | HTMLOptGroupElement;
 }
 
 declare var HTMLSelectElement: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1059,7 +1059,7 @@
                     }
                 ],
                 "override-index-signatures": [
-                    "[name: string]: HTMLOptionElement | HTMLOptGroupElement"
+                    "[name: number]: HTMLOptionElement | HTMLOptGroupElement"
                 ]
             },
             "HTMLDataListElement": {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1057,6 +1057,9 @@
                     {
                         "name": "select"
                     }
+                ],
+                "override-index-signatures": [
+                    "[name: string]: HTMLOptionElement | HTMLOptGroupElement"
                 ]
             },
             "HTMLDataListElement": {


### PR DESCRIPTION
This PR addresses https://github.com/Microsoft/TypeScript/issues/24084.

I changed the `HTMLSelectElement` index to `[name: string]: HTMLOptionElement | HTMLOptGroupElement`.

Thanks for considering this PR.