### PR TITLE
Mark document.implementation.hasFeature as deprecated

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3320,7 +3320,8 @@ interface DOMImplementation {
     createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document;
     createDocumentType(qualifiedName: string, publicId: string, systemId: string): DocumentType;
     createHTMLDocument(title?: string): Document;
-    hasFeature(feature: string | null, version: string | null): boolean;
+    /** @deprecated */
+    hasFeature(...args: any[]): true;
 }
 
 declare var DOMImplementation: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1433,8 +1433,9 @@
                         "hasFeature": {
                             "name": "hasFeature",
                             "override-signatures": [
-                                "hasFeature(feature: string | null, version: string | null): boolean"
-                            ]
+                                "hasFeature(...args: any[]): true"
+                            ],
+                            "deprecated": 1
                         },
                         "createDocument": {
                             "name": "createDocument",


### PR DESCRIPTION
[The spec](https://dom.spec.whatwg.org/#dom-domimplementation-hasfeature) says it's now useless and always returns `true` for web compatilibity.

The IDL specifies zero arguments but here we intentionally want to allow arbitrary arguments to not break backward compatibility. (Web IDL implicitly allows excessive arguments, anyway.)