### PR TITLE
Introduce Messageable and Transferable for postMessage

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2195,7 +2195,7 @@ interface BroadcastChannel extends EventTarget {
     /**
      * Sends the given message to other BroadcastChannel objects set up for this channel. Messages can be structured objects, e.g. nested objects and arrays.
      */
-    postMessage(message: any): void;
+    postMessage(message: Messageable): void;
     addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -9914,7 +9914,7 @@ interface MessagePort extends EventTarget {
      * transfer contains duplicate objects or port, or if message
      * could not be cloned.
      */
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transferList?: Transferable[]): void;
     /**
      * Begins dispatching messages received on the port.
      */
@@ -13943,7 +13943,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
     onstatechange: ((this: ServiceWorker, ev: Event) => any) | null;
     readonly scriptURL: string;
     readonly state: ServiceWorkerState;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transfer?: Transferable[]): void;
     addEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -16376,7 +16376,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     moveTo(x: number, y: number): void;
     msWriteProfilerMark(profilerMarkName: string): void;
     open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
-    postMessage(message: any, targetOrigin: string, transfer?: any[]): void;
+    postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void;
     print(): void;
     prompt(message?: string, _default?: string): string | null;
     /** @deprecated */
@@ -16489,7 +16489,7 @@ interface WorkerEventMap extends AbstractWorkerEventMap {
 
 interface Worker extends EventTarget, AbstractWorker {
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transferList?: Transferable[]): void;
     terminate(): void;
     addEventListener<K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -17230,7 +17230,7 @@ declare function moveBy(x: number, y: number): void;
 declare function moveTo(x: number, y: number): void;
 declare function msWriteProfilerMark(profilerMarkName: string): void;
 declare function open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
-declare function postMessage(message: any, targetOrigin: string, transfer?: any[]): void;
+declare function postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void;
 declare function print(): void;
 declare function prompt(message?: string, _default?: string): string | null;
 /** @deprecated */
@@ -17574,6 +17574,8 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainLong = number | ConstrainLongRange;
 type CryptoOperationData = ArrayBufferView;
 type IDBKeyPath = string;
+type Messageable = number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>;
+type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type RTCIceGatherCandidate = RTCIceCandidateDictionary | RTCIceCandidateComplete;
 type RTCTransport = RTCDtlsTransport | RTCSrtpSdesTransport;
 type WindowProxy = Window;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2195,7 +2195,7 @@ interface BroadcastChannel extends EventTarget {
     /**
      * Sends the given message to other BroadcastChannel objects set up for this channel. Messages can be structured objects, e.g. nested objects and arrays.
      */
-    postMessage(message: Messageable): void;
+    postMessage(message: any): void;
     addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -9914,7 +9914,7 @@ interface MessagePort extends EventTarget {
      * transfer contains duplicate objects or port, or if message
      * could not be cloned.
      */
-    postMessage(message: Messageable, transferList?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     /**
      * Begins dispatching messages received on the port.
      */
@@ -13943,7 +13943,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
     onstatechange: ((this: ServiceWorker, ev: Event) => any) | null;
     readonly scriptURL: string;
     readonly state: ServiceWorkerState;
-    postMessage(message: Messageable, transfer?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     addEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -16376,7 +16376,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     moveTo(x: number, y: number): void;
     msWriteProfilerMark(profilerMarkName: string): void;
     open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
-    postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void;
+    postMessage(message: any, targetOrigin: string, transfer?: Transferable[]): void;
     print(): void;
     prompt(message?: string, _default?: string): string | null;
     /** @deprecated */
@@ -16489,7 +16489,7 @@ interface WorkerEventMap extends AbstractWorkerEventMap {
 
 interface Worker extends EventTarget, AbstractWorker {
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null;
-    postMessage(message: Messageable, transferList?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     terminate(): void;
     addEventListener<K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -17230,7 +17230,7 @@ declare function moveBy(x: number, y: number): void;
 declare function moveTo(x: number, y: number): void;
 declare function msWriteProfilerMark(profilerMarkName: string): void;
 declare function open(url?: string, target?: string, features?: string, replace?: boolean): Window | null;
-declare function postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void;
+declare function postMessage(message: any, targetOrigin: string, transfer?: Transferable[]): void;
 declare function print(): void;
 declare function prompt(message?: string, _default?: string): string | null;
 /** @deprecated */
@@ -17574,7 +17574,6 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainLong = number | ConstrainLongRange;
 type CryptoOperationData = ArrayBufferView;
 type IDBKeyPath = string;
-type Messageable = number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type RTCIceGatherCandidate = RTCIceCandidateDictionary | RTCIceCandidateComplete;
 type RTCTransport = RTCDtlsTransport | RTCSrtpSdesTransport;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -378,7 +378,7 @@ interface BroadcastChannel extends EventTarget {
     /**
      * Sends the given message to other BroadcastChannel objects set up for this channel. Messages can be structured objects, e.g. nested objects and arrays.
      */
-    postMessage(message: Messageable): void;
+    postMessage(message: any): void;
     addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -468,7 +468,7 @@ interface Client {
     readonly id: string;
     readonly type: ClientTypes;
     readonly url: string;
-    postMessage(message: Messageable, transfer?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
 }
 
 declare var Client: {
@@ -829,7 +829,7 @@ interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
 interface DedicatedWorkerGlobalScope extends WorkerGlobalScope {
     onmessage: ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any) | null;
     close(): void;
-    postMessage(message: Messageable, transfer?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     addEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1744,7 +1744,7 @@ interface MessagePort extends EventTarget {
      * transfer contains duplicate objects or port, or if message
      * could not be cloned.
      */
-    postMessage(message: Messageable, transferList?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     /**
      * Begins dispatching messages received on the port.
      */
@@ -2188,7 +2188,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
     onstatechange: ((this: ServiceWorker, ev: Event) => any) | null;
     readonly scriptURL: string;
     readonly state: ServiceWorkerState;
-    postMessage(message: Messageable, transfer?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     addEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -2514,7 +2514,7 @@ interface WorkerEventMap extends AbstractWorkerEventMap {
 
 interface Worker extends EventTarget, AbstractWorker {
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null;
-    postMessage(message: Messageable, transferList?: Transferable[]): void;
+    postMessage(message: any, transfer?: Transferable[]): void;
     terminate(): void;
     addEventListener<K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -2747,7 +2747,7 @@ interface PerformanceObserverCallback {
 
 declare var onmessage: ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any) | null;
 declare function close(): void;
-declare function postMessage(message: Messageable, transfer?: Transferable[]): void;
+declare function postMessage(message: any, transfer?: Transferable[]): void;
 /**
  * Dispatches a synthetic event event to target and returns true
  * if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
@@ -2805,7 +2805,6 @@ type BufferSource = ArrayBufferView | ArrayBuffer;
 type DOMTimeStamp = number;
 type FormDataEntryValue = File | string;
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
-type Messageable = number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type BinaryType = "blob" | "arraybuffer";
 type ClientTypes = "window" | "worker" | "sharedworker" | "all";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -378,7 +378,7 @@ interface BroadcastChannel extends EventTarget {
     /**
      * Sends the given message to other BroadcastChannel objects set up for this channel. Messages can be structured objects, e.g. nested objects and arrays.
      */
-    postMessage(message: any): void;
+    postMessage(message: Messageable): void;
     addEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof BroadcastChannelEventMap>(type: K, listener: (this: BroadcastChannel, ev: BroadcastChannelEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -468,7 +468,7 @@ interface Client {
     readonly id: string;
     readonly type: ClientTypes;
     readonly url: string;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transfer?: Transferable[]): void;
 }
 
 declare var Client: {
@@ -829,7 +829,7 @@ interface DedicatedWorkerGlobalScopeEventMap extends WorkerGlobalScopeEventMap {
 interface DedicatedWorkerGlobalScope extends WorkerGlobalScope {
     onmessage: ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any) | null;
     close(): void;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transfer?: Transferable[]): void;
     addEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof DedicatedWorkerGlobalScopeEventMap>(type: K, listener: (this: DedicatedWorkerGlobalScope, ev: DedicatedWorkerGlobalScopeEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -1744,7 +1744,7 @@ interface MessagePort extends EventTarget {
      * transfer contains duplicate objects or port, or if message
      * could not be cloned.
      */
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transferList?: Transferable[]): void;
     /**
      * Begins dispatching messages received on the port.
      */
@@ -2188,7 +2188,7 @@ interface ServiceWorker extends EventTarget, AbstractWorker {
     onstatechange: ((this: ServiceWorker, ev: Event) => any) | null;
     readonly scriptURL: string;
     readonly state: ServiceWorkerState;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transfer?: Transferable[]): void;
     addEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof ServiceWorkerEventMap>(type: K, listener: (this: ServiceWorker, ev: ServiceWorkerEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -2514,7 +2514,7 @@ interface WorkerEventMap extends AbstractWorkerEventMap {
 
 interface Worker extends EventTarget, AbstractWorker {
     onmessage: ((this: Worker, ev: MessageEvent) => any) | null;
-    postMessage(message: any, transfer?: any[]): void;
+    postMessage(message: Messageable, transferList?: Transferable[]): void;
     terminate(): void;
     addEventListener<K extends keyof WorkerEventMap>(type: K, listener: (this: Worker, ev: WorkerEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -2747,7 +2747,7 @@ interface PerformanceObserverCallback {
 
 declare var onmessage: ((this: DedicatedWorkerGlobalScope, ev: MessageEvent) => any) | null;
 declare function close(): void;
-declare function postMessage(message: any, transfer?: any[]): void;
+declare function postMessage(message: Messageable, transfer?: Transferable[]): void;
 /**
  * Dispatches a synthetic event event to target and returns true
  * if either event's cancelable attribute value is false or its preventDefault() method was not invoked, and false otherwise.
@@ -2805,6 +2805,8 @@ type BufferSource = ArrayBufferView | ArrayBuffer;
 type DOMTimeStamp = number;
 type FormDataEntryValue = File | string;
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
+type Messageable = number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>;
+type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type BinaryType = "blob" | "arraybuffer";
 type ClientTypes = "window" | "worker" | "sharedworker" | "all";
 type IDBCursorDirection = "next" | "nextunique" | "prev" | "prevunique";

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2529,6 +2529,14 @@
                 "override-type": "string"
             },
             {
+                "new-type": "Messageable",
+                "override-type": "number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>"
+            },
+            {
+                "new-type": "Transferable",
+                "override-type": "ArrayBuffer | MessagePort | ImageBitmap"
+            },
+            {
                 "new-type": "RTCIceGatherCandidate",
                 "override-type": "RTCIceCandidateDictionary | RTCIceCandidateComplete"
             },

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2529,10 +2529,6 @@
                 "override-type": "string"
             },
             {
-                "new-type": "Messageable",
-                "override-type": "number | string | boolean | null | undefined | Date | ImageData | Number | Boolean | String | Date | RegExp | Blob | File | FileList | ArrayBuffer | ArrayBufferView | Map<any, any> | Set<any>"
-            },
-            {
                 "new-type": "Transferable",
                 "override-type": "ArrayBuffer | MessagePort | ImageBitmap"
             },

--- a/inputfiles/knownTypes.json
+++ b/inputfiles/knownTypes.json
@@ -40,6 +40,7 @@
         "KeyType",
         "KeyUsage",
         "Keyframe",
+        "Messageable",
         "MutationRecordType",
         "Pbkdf2Params",
         "PropertyIndexedKeyframes",
@@ -77,11 +78,14 @@
         "RsaKeyGenParams",
         "RsaOaepParams",
         "RsaPssParams",
+        "Transferable",
         "VideoFacingModeEnum"
     ],
     "Worker": [
         "ClientTypes",
         "IDBArrayKey",
-        "IDBValidKey"
+        "IDBValidKey",
+        "Messageable",
+        "Transferable"
     ]
 }

--- a/inputfiles/knownTypes.json
+++ b/inputfiles/knownTypes.json
@@ -40,7 +40,6 @@
         "KeyType",
         "KeyUsage",
         "Keyframe",
-        "Messageable",
         "MutationRecordType",
         "Pbkdf2Params",
         "PropertyIndexedKeyframes",
@@ -85,7 +84,6 @@
         "ClientTypes",
         "IDBArrayKey",
         "IDBValidKey",
-        "Messageable",
         "Transferable"
     ]
 }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -274,7 +274,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void"
+                                "postMessage(message: any, targetOrigin: string, transfer?: Transferable[]): void"
                             ]
                         }
                     }
@@ -1909,7 +1909,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                                "postMessage(message: any, transfer?: Transferable[]): void"
                             ]
                         }
                     }
@@ -2255,7 +2255,7 @@
                         "postMessage": {
                             "deprecated": 0,
                             "override-signatures": [
-                                "postMessage(message: Messageable, transferList?: Transferable[]): void"
+                                "postMessage(message: any, transfer?: Transferable[]): void"
                             ]
                         }
                     }
@@ -2345,7 +2345,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable): void"
+                                "postMessage(message: any): void"
                             ]
                         }
                     }
@@ -2358,7 +2358,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable, transferList?: Transferable[]): void"
+                                "postMessage(message: any, transfer?: Transferable[]): void"
                             ]
                         }
                     }
@@ -2371,7 +2371,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                                "postMessage(message: any, transfer?: Transferable[]): void"
                             ]
                         }
                     }
@@ -2384,7 +2384,7 @@
                         "postMessage": {
                             "name": "postMessage",
                             "override-signatures": [
-                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                                "postMessage(message: any, transfer?: Transferable[]): void"
                             ]
                         }
                     }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -270,6 +270,12 @@
                             "override-signatures": [
                                 "alert(message?: any): void"
                             ]
+                        },
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable, targetOrigin: string, transfer?: Transferable[]): void"
+                            ]
                         }
                     }
                 },
@@ -1897,6 +1903,16 @@
                             "override-type": "ClientTypes"
                         }
                     }
+                },
+                "methods": {
+                    "method": {
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                            ]
+                        }
+                    }
                 }
             },
             "RTCDataChannel": {
@@ -2237,7 +2253,10 @@
                 "methods": {
                     "method": {
                         "postMessage": {
-                            "deprecated": 0
+                            "deprecated": 0,
+                            "override-signatures": [
+                                "postMessage(message: Messageable, transferList?: Transferable[]): void"
+                            ]
                         }
                     }
                 }
@@ -2317,6 +2336,58 @@
                             "type": "AudioProcessingEvent"
                         }
                     ]
+                }
+            },
+            "BroadcastChannel": {
+                "name": "BroadcastChannel",
+                "methods": {
+                    "method": {
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable): void"
+                            ]
+                        }
+                    }
+                }
+            },
+            "MessagePort": {
+                "name": "MessagePort",
+                "methods": {
+                    "method": {
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable, transferList?: Transferable[]): void"
+                            ]
+                        }
+                    }
+                }
+            },
+            "ServiceWorker": {
+                "name": "ServiceWorker",
+                "methods": {
+                    "method": {
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                            ]
+                        }
+                    }
+                }
+            },
+            "DedicatedWorkerGlobalScope": {
+                "name": "DedicatedWorkerGlobalScope",
+                "methods": {
+                    "method": {
+                        "postMessage": {
+                            "name": "postMessage",
+                            "override-signatures": [
+                                "postMessage(message: Messageable, transfer?: Transferable[]): void"
+                            ]
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR addresses https://github.com/Microsoft/TypeScript/issues/25176

Relevant MDN pages:
https://developer.mozilla.org/en-US/docs/Web/API/BroadcastChannel/postMessage
https://developer.mozilla.org/en-US/docs/Web/API/Window/postMessage
https://developer.mozilla.org/en-US/docs/Web/API/Client/postMessage
https://developer.mozilla.org/en-US/docs/Web/API/Worker/postMessage
https://developer.mozilla.org/en-US/docs/Web/API/MessagePort/postMessage
https://developer.mozilla.org/en-US/docs/Web/API/DedicatedWorkerGlobalScope/postMessage

Map and Set do not seem to be available in `dom.generated.d.ts`. How would one implement the `Messageable` type?
