### PR TITLE
Correct use of --project parameter

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "tsjs-lib-generator",
   "private": true,
   "scripts": {
-    "build": "tsc --p ./tsconfig.json && node ./lib/index.js",
-    "fetch": "tsc --p ./tsconfig.json && node ./lib/fetcher.js",
+    "build": "tsc --project ./tsconfig.json && node ./lib/index.js",
+    "fetch": "tsc --project ./tsconfig.json && node ./lib/fetcher.js",
     "baseline-accept": "cpx \"generated\\*\" baselines\\",
-    "test": "tsc --p ./tsconfig.json && node ./lib/index.js && node ./lib/test.js"
+    "test": "tsc --project ./tsconfig.json && node ./lib/index.js && node ./lib/test.js"
   },
   "dependencies": {
     "@types/jsdom": "^11.0.4",


### PR DESCRIPTION
`tsc --help` outputs (as of Version 2.9.2):

```
...
-p FILE OR DIRECTORY, --project FILE OR DIRECTORY
...
```

In the `package.json` scripts, `--p` is used, which is wrong accorging to the help docs. This may also be the reason the appveyor build fails.

This PR changes the compiler invocation to `--project`.

Edit: The appveyor build still fails. It may be that an old `tsc` version is used that does not support `--project`.