### PR TITLE
Change FileReader.readAsText‘s 2nd argument name

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -142,6 +142,7 @@ interface BiquadFilterOptions extends AudioNodeOptions {
 }
 
 interface BlobPropertyBag {
+    endings?: EndingType;
     type?: string;
 }
 
@@ -5013,7 +5014,7 @@ interface FileReader extends EventTarget {
     readAsArrayBuffer(blob: Blob): void;
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
-    readAsText(blob: Blob, label?: string): void;
+    readAsText(blob: Blob, encoding?: string): void;
     readonly DONE: number;
     readonly EMPTY: number;
     readonly LOADING: number;
@@ -17653,6 +17654,7 @@ type DisplayCaptureSurfaceType = "monitor" | "window" | "application" | "browser
 type DistanceModelType = "linear" | "inverse" | "exponential";
 type DocumentReadyState = "loading" | "interactive" | "complete";
 type EndOfStreamError = "network" | "decode";
+type EndingType = "transparent" | "native";
 type FillMode = "none" | "forwards" | "backwards" | "both" | "auto";
 type GamepadHand = "" | "left" | "right";
 type GamepadHapticActuatorType = "vibration";

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -39,6 +39,7 @@ interface Algorithm {
 }
 
 interface BlobPropertyBag {
+    endings?: EndingType;
     type?: string;
 }
 
@@ -1197,7 +1198,7 @@ interface FileReader extends EventTarget {
     readAsArrayBuffer(blob: Blob): void;
     readAsBinaryString(blob: Blob): void;
     readAsDataURL(blob: Blob): void;
-    readAsText(blob: Blob, label?: string): void;
+    readAsText(blob: Blob, encoding?: string): void;
     readonly DONE: number;
     readonly EMPTY: number;
     readonly LOADING: number;
@@ -1219,7 +1220,7 @@ interface FileReaderSync {
     readAsArrayBuffer(blob: Blob): ArrayBuffer;
     readAsBinaryString(blob: Blob): string;
     readAsDataURL(blob: Blob): string;
-    readAsText(blob: Blob, label?: string): string;
+    readAsText(blob: Blob, encoding?: string): string;
 }
 
 declare var FileReaderSync: {
@@ -2967,6 +2968,7 @@ type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type BinaryType = "blob" | "arraybuffer";
 type ClientTypes = "window" | "worker" | "sharedworker" | "all";
+type EndingType = "transparent" | "native";
 type IDBCursorDirection = "next" | "nextunique" | "prev" | "prevunique";
 type IDBRequestReadyState = "pending" | "done";
 type IDBTransactionMode = "readonly" | "readwrite" | "versionchange";

--- a/inputfiles/idl/File.widl
+++ b/inputfiles/idl/File.widl
@@ -12,8 +12,11 @@ interface Blob {
             optional DOMString contentType);
 };
 
+enum EndingType { "transparent", "native" };
+
 dictionary BlobPropertyBag {
   DOMString type = "";
+  EndingType endings = "transparent";
 };
 
 typedef (BufferSource or Blob or USVString) BlobPart;
@@ -43,7 +46,7 @@ interface FileReader: EventTarget {
   // async read methods
   void readAsArrayBuffer(Blob blob);
   void readAsBinaryString(Blob blob);
-  void readAsText(Blob blob, optional DOMString label);
+  void readAsText(Blob blob, optional DOMString encoding);
   void readAsDataURL(Blob blob);
 
   void abort();
@@ -77,7 +80,7 @@ interface FileReaderSync {
 
   ArrayBuffer readAsArrayBuffer(Blob blob);
   DOMString readAsBinaryString(Blob blob);
-  DOMString readAsText(Blob blob, optional DOMString label);
+  DOMString readAsText(Blob blob, optional DOMString encoding);
   DOMString readAsDataURL(Blob blob);
 };
 

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -29,7 +29,7 @@
         "title": "Encoding"
     },
     {
-        "url": "https://www.w3.org/TR/FileAPI/",
+        "url": "https://w3c.github.io/FileAPI/",
         "title": "File"
     },
     {


### PR DESCRIPTION
Change from `label` to the more descriptive `encoding` ([MDN docs][1]).

[1]: https://developer.mozilla.org/en-US/docs/Web/API/FileReader/readAsText

Fixes Microsoft/TypeScript#25797