### PR TITLE
Type unhandledrejection event of WindowEventHandlers

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16430,7 +16430,7 @@ interface WindowEventHandlersEventMap {
     "popstate": PopStateEvent;
     "rejectionhandled": Event;
     "storage": StorageEvent;
-    "unhandledrejection": Event;
+    "unhandledrejection": PromiseRejectionEvent;
     "unload": Event;
 }
 
@@ -16449,7 +16449,7 @@ interface WindowEventHandlers {
     onpopstate: ((this: WindowEventHandlers, ev: PopStateEvent) => any) | null;
     onrejectionhandled: ((this: WindowEventHandlers, ev: Event) => any) | null;
     onstorage: ((this: WindowEventHandlers, ev: StorageEvent) => any) | null;
-    onunhandledrejection: ((this: WindowEventHandlers, ev: Event) => any) | null;
+    onunhandledrejection: ((this: WindowEventHandlers, ev: PromiseRejectionEvent) => any) | null;
     onunload: ((this: WindowEventHandlers, ev: Event) => any) | null;
     addEventListener<K extends keyof WindowEventHandlersEventMap>(type: K, listener: (this: WindowEventHandlers, ev: WindowEventHandlersEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -121,6 +121,16 @@
                     ]
                 }
             },
+            "WindowEventHandlers": {
+                "events": {
+                    "event": [
+                        {
+                            "name": "unhandledrejection",
+                            "type": "PromiseRejectionEvent"
+                        }
+                    ]
+                }
+            },
             "HTMLHyperlinkElementUtils": {
                 "name": "HTMLHyperlinkElementUtils",
                 "properties": {


### PR DESCRIPTION
Specification:
https://html.spec.whatwg.org/multipage/webappapis.html#unhandled-promise-rejections
> Let _notHandled_ be the result of [firing an event](https://dom.spec.whatwg.org/#concept-event-fire) named [`unhandledrejection`](https://html.spec.whatwg.org/multipage/indices.html#event-unhandledrejection) at settings object's [global object](https://html.spec.whatwg.org/multipage/webappapis.html#concept-settings-object-global), using [`PromiseRejectionEvent`](https://html.spec.whatwg.org/multipage/webappapis.html#promiserejectionevent), …