### PR TITLE
Add WebVR types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1709,16 +1709,10 @@ interface VRDisplayEventInit extends EventInit {
     reason?: VRDisplayEventReason;
 }
 
-interface VRLayer {
-    leftBounds?: number[] | Float32Array | null;
-    rightBounds?: number[] | Float32Array | null;
-    source?: HTMLCanvasElement | null;
-}
-
-interface VRStageParameters {
-    sittingToStandingTransform?: Float32Array;
-    sizeX?: number;
-    sizeY?: number;
+interface VRLayerInit {
+    leftBounds?: number[] | Float32Array;
+    rightBounds?: number[] | Float32Array;
+    source?: VRSource | null;
 }
 
 interface WaveShaperOptions extends AudioNodeOptions {
@@ -5520,6 +5514,8 @@ interface Gamepad {
     readonly axes: ReadonlyArray<number>;
     readonly buttons: ReadonlyArray<GamepadButton>;
     readonly connected: boolean;
+    /** @deprecated */
+    readonly displayId: number;
     readonly hand: GamepadHand;
     readonly hapticActuators: ReadonlyArray<GamepadHapticActuator>;
     readonly id: string;
@@ -10698,6 +10694,7 @@ declare var NavigationPreloadManager: {
 
 /** The state and the identity of the user agent. It allows scripts to query it and to register themselves to carry on some activities. */
 interface Navigator extends NavigatorID, NavigatorOnLine, NavigatorContentUtils, NavigatorStorageUtils, MSNavigatorDoNotTrack, MSFileSaver, NavigatorBeacon, NavigatorConcurrentHardware, NavigatorUserMedia, NavigatorLanguage, NavigatorStorage, NavigatorAutomationInformation {
+    /** @deprecated */
     readonly activeVRDisplays: ReadonlyArray<VRDisplay>;
     readonly authentication: WebAuthentication;
     readonly clipboard: Clipboard;
@@ -10719,6 +10716,7 @@ interface Navigator extends NavigatorID, NavigatorOnLine, NavigatorContentUtils,
     readonly webdriver: boolean;
     getGamepads(): (Gamepad | null)[];
     getUserMedia(constraints: MediaStreamConstraints, successCallback: NavigatorUserMediaSuccessCallback, errorCallback: NavigatorUserMediaErrorCallback): void;
+    /** @deprecated */
     getVRDisplays(): Promise<VRDisplay[]>;
     javaEnabled(): boolean;
     msLaunchUri(uri: string, successCallback?: MSLaunchUriCallback, noHandlerCallback?: MSLaunchUriCallback): void;
@@ -15906,25 +15904,42 @@ declare var URLSearchParams: {
 
 /** This WebVR API interface represents any VR device supported by this API. It includes generic information such as device IDs and descriptions, as well as methods for starting to present a VR scene, retrieving eye parameters and display capabilities, and other important functionality. */
 interface VRDisplay extends EventTarget {
+    /** @deprecated */
     readonly capabilities: VRDisplayCapabilities;
+    /** @deprecated */
     depthFar: number;
+    /** @deprecated */
     depthNear: number;
+    /** @deprecated */
     readonly displayId: number;
+    /** @deprecated */
     readonly displayName: string;
+    /** @deprecated */
     readonly isConnected: boolean;
+    /** @deprecated */
     readonly isPresenting: boolean;
+    /** @deprecated */
     readonly stageParameters: VRStageParameters | null;
+    /** @deprecated */
     cancelAnimationFrame(handle: number): void;
+    /** @deprecated */
     exitPresent(): Promise<void>;
-    getEyeParameters(whichEye: string): VREyeParameters;
+    /** @deprecated */
+    getEyeParameters(whichEye: VREye): VREyeParameters;
+    /** @deprecated */
     getFrameData(frameData: VRFrameData): boolean;
-    getLayers(): VRLayer[];
+    /** @deprecated */
+    getLayers(): VRLayerInit[];
     /** @deprecated */
     getPose(): VRPose;
+    /** @deprecated */
     requestAnimationFrame(callback: FrameRequestCallback): number;
-    requestPresent(layers: VRLayer[]): Promise<void>;
+    /** @deprecated */
+    requestPresent(layers: VRLayerInit[]): Promise<void>;
+    /** @deprecated */
     resetPose(): void;
-    submitFrame(pose?: VRPose): void;
+    /** @deprecated */
+    submitFrame(): void;
 }
 
 declare var VRDisplay: {
@@ -15934,10 +15949,15 @@ declare var VRDisplay: {
 
 /** This WebVR API interface describes the capabilities of a VRDisplay — its features can be used to perform VR device capability tests, for example can it return position information. */
 interface VRDisplayCapabilities {
+    /** @deprecated */
     readonly canPresent: boolean;
+    /** @deprecated */
     readonly hasExternalDisplay: boolean;
+    /** @deprecated */
     readonly hasOrientation: boolean;
+    /** @deprecated */
     readonly hasPosition: boolean;
+    /** @deprecated */
     readonly maxLayers: number;
 }
 
@@ -15948,7 +15968,9 @@ declare var VRDisplayCapabilities: {
 
 /** This WebVR API interface represents represents the event object of WebVR-related events (see the list of WebVR window extensions). */
 interface VRDisplayEvent extends Event {
+    /** @deprecated */
     readonly display: VRDisplay;
+    /** @deprecated */
     readonly reason: VRDisplayEventReason | null;
 }
 
@@ -15961,8 +15983,11 @@ declare var VRDisplayEvent: {
 interface VREyeParameters {
     /** @deprecated */
     readonly fieldOfView: VRFieldOfView;
+    /** @deprecated */
     readonly offset: Float32Array;
+    /** @deprecated */
     readonly renderHeight: number;
+    /** @deprecated */
     readonly renderWidth: number;
 }
 
@@ -15973,9 +15998,13 @@ declare var VREyeParameters: {
 
 /** This WebVR API interface represents a field of view defined by 4 different degree values describing the view from a center point. */
 interface VRFieldOfView {
+    /** @deprecated */
     readonly downDegrees: number;
+    /** @deprecated */
     readonly leftDegrees: number;
+    /** @deprecated */
     readonly rightDegrees: number;
+    /** @deprecated */
     readonly upDegrees: number;
 }
 
@@ -15986,11 +16015,17 @@ declare var VRFieldOfView: {
 
 /** This WebVR API interface represents all the information needed to render a single frame of a VR scene; constructed by VRDisplay.getFrameData(). */
 interface VRFrameData {
+    /** @deprecated */
     readonly leftProjectionMatrix: Float32Array;
+    /** @deprecated */
     readonly leftViewMatrix: Float32Array;
+    /** @deprecated */
     readonly pose: VRPose;
+    /** @deprecated */
     readonly rightProjectionMatrix: Float32Array;
+    /** @deprecated */
     readonly rightViewMatrix: Float32Array;
+    /** @deprecated */
     readonly timestamp: number;
 }
 
@@ -16001,18 +16036,37 @@ declare var VRFrameData: {
 
 /** This WebVR API interface represents the state of a VR sensor at a given timestamp (which includes orientation, position, velocity, and acceleration information.) */
 interface VRPose {
+    /** @deprecated */
     readonly angularAcceleration: Float32Array | null;
+    /** @deprecated */
     readonly angularVelocity: Float32Array | null;
+    /** @deprecated */
     readonly linearAcceleration: Float32Array | null;
+    /** @deprecated */
     readonly linearVelocity: Float32Array | null;
+    /** @deprecated */
     readonly orientation: Float32Array | null;
+    /** @deprecated */
     readonly position: Float32Array | null;
-    readonly timestamp: number;
 }
 
 declare var VRPose: {
     prototype: VRPose;
     new(): VRPose;
+};
+
+interface VRStageParameters {
+    /** @deprecated */
+    readonly sittingToStandingTransform: Float32Array;
+    /** @deprecated */
+    readonly sizeX: number;
+    /** @deprecated */
+    readonly sizeZ: number;
+}
+
+declare var VRStageParameters: {
+    prototype: VRStageParameters;
+    new(): VRStageParameters;
 };
 
 interface VTTCue extends TextTrackCue {
@@ -18385,14 +18439,23 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     /** @deprecated */
     onorientationchange: ((this: Window, ev: Event) => any) | null;
     onreadystatechange: ((this: Window, ev: ProgressEvent) => any) | null;
+    /** @deprecated */
     onvrdisplayactivate: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplayblur: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplayconnect: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplaydeactivate: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplaydisconnect: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
+    /** @deprecated */
     onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
     opener: any;
     /** @deprecated */
@@ -19379,14 +19442,23 @@ declare var onmspointerup: ((this: Window, ev: Event) => any) | null;
 /** @deprecated */
 declare var onorientationchange: ((this: Window, ev: Event) => any) | null;
 declare var onreadystatechange: ((this: Window, ev: ProgressEvent) => any) | null;
+/** @deprecated */
 declare var onvrdisplayactivate: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplayblur: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplayconnect: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplaydeactivate: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplaydisconnect: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplayfocus: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplaypointerrestricted: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplaypointerunrestricted: ((this: Window, ev: Event) => any) | null;
+/** @deprecated */
 declare var onvrdisplaypresentchange: ((this: Window, ev: Event) => any) | null;
 declare var opener: any;
 /** @deprecated */
@@ -19807,6 +19879,7 @@ type GLuint64 = number;
 type Uint32List = Uint32Array | GLuint[];
 type BufferSource = ArrayBufferView | ArrayBuffer;
 type DOMTimeStamp = number;
+type VRSource = HTMLCanvasElement | OffscreenCanvas;
 type LineAndPositionSetting = number | AutoKeyword;
 type FormDataEntryValue = File | string;
 type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
@@ -19945,6 +20018,7 @@ type TextTrackMode = "disabled" | "hidden" | "showing";
 type TouchType = "direct" | "stylus";
 type Transport = "usb" | "nfc" | "ble";
 type VRDisplayEventReason = "mounted" | "navigation" | "requested" | "unmounted";
+type VREye = "left" | "right";
 type VideoFacingModeEnum = "user" | "environment" | "left" | "right";
 type VisibilityState = "hidden" | "visible" | "prerender";
 type WebGLPowerPreference = "default" | "low-power" | "high-performance";

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -257,7 +257,8 @@ interface URLSearchParams {
 }
 
 interface VRDisplay {
-    requestPresent(layers: Iterable<VRLayer>): Promise<void>;
+    /** @deprecated */
+    requestPresent(layers: Iterable<VRLayerInit>): Promise<void>;
 }
 
 interface VideoTrackList {

--- a/inputfiles/idl/WebVR.widl
+++ b/inputfiles/idl/WebVR.widl
@@ -1,0 +1,229 @@
+interface VRDisplay : EventTarget {
+  readonly attribute boolean isConnected;
+  readonly attribute boolean isPresenting;
+
+  /**
+   * Dictionary of capabilities describing the VRDisplay.
+   */
+  [SameObject] readonly attribute VRDisplayCapabilities capabilities;
+
+  /**
+   * If this VRDisplay supports room-scale experiences, the optional
+   * stage attribute contains details on the room-scale parameters.
+   * The stageParameters attribute can not change between null
+   * and non-null once the VRDisplay is enumerated; however,
+   * the values within VRStageParameters may change after
+   * any call to VRDisplay.submitFrame as the user may re-configure
+   * their environment at any time.
+   */
+  readonly attribute VRStageParameters? stageParameters;
+
+  /**
+   * Return the current VREyeParameters for the given eye.
+   */
+  VREyeParameters getEyeParameters(VREye whichEye);
+
+  /**
+   * An identifier for this distinct VRDisplay. Used as an
+   * association point in the Gamepad API.
+   */
+  readonly attribute unsigned long displayId;
+
+  /**
+   * A display name, a user-readable name identifying it.
+   */
+  readonly attribute DOMString displayName;
+
+  /**
+   * Populates the passed VRFrameData with the information required to render
+   * the current frame. The value provided will not change until JavaScript has
+   * returned control to the browser. Only valid to call in a
+   * VRDisplay.requestAnimationFrame callback.
+   */
+  boolean getFrameData(VRFrameData frameData);
+
+  /**
+   * Return a VRPose containing the future predicted pose of the VRDisplay
+   * when the current frame will be presented. The value returned will not
+   * change until JavaScript has returned control to the browser.
+   *
+   * The VRPose will contain the position, orientation, velocity,
+   * and acceleration of each of these properties.
+   */
+  [NewObject] VRPose getPose();
+
+  /**
+   * Reset the pose for this display, treating its current position and
+   * orientation as the "origin/zero" values. VRPose.position,
+   * VRPose.orientation, and VRStageParameters.sittingToStandingTransform may be
+   * updated when calling resetPose(). This should be called in only
+   * sitting-space experiences.
+   */
+  void resetPose();
+
+  /**
+   * z-depth defining the near plane of the eye view frustum
+   * enables mapping of values in the render target depth
+   * attachment to scene coordinates. Initially set to 0.01.
+   */
+  attribute double depthNear;
+
+  /**
+   * z-depth defining the far plane of the eye view frustum
+   * enables mapping of values in the render target depth
+   * attachment to scene coordinates. Initially set to 10000.0.
+   */
+  attribute double depthFar;
+
+  /**
+   * The callback passed to `requestAnimationFrame` will be called
+   * any time a new frame should be rendered. When the VRDisplay is
+   * presenting the callback will be called at the native refresh
+   * rate of the HMD. When not presenting this function acts
+   * identically to how window.requestAnimationFrame acts. Content should
+   * make no assumptions of frame rate or vsync behavior as the HMD runs
+   * asynchronously from other displays and at differing refresh rates.
+   */
+  long requestAnimationFrame(FrameRequestCallback callback);
+
+  /**
+   * Passing the value returned by `requestAnimationFrame` to
+   * `cancelAnimationFrame` will unregister the callback.
+   */
+  void cancelAnimationFrame(long handle);
+
+  /**
+   * Begin presenting to the VRDisplay. Must be called in response to a user gesture.
+   * Repeat calls while already presenting will update the layers being displayed.
+   * If the number of values in the leftBounds/rightBounds arrays is not 0 or 4 for any of the passed layers the promise is rejected
+   * If the source of any of the layers is not present (null), the promise is rejected.
+   */
+  Promise<void> requestPresent(sequence<VRLayerInit> layers);
+
+  /**
+   * Stops presenting to the VRDisplay.
+   */
+  Promise<void> exitPresent();
+
+  /**
+   * Get the layers currently being presented.
+   */
+  sequence<VRLayerInit> getLayers();
+
+  /**
+   * The layer provided to the VRDisplay will be captured and presented
+   * in the HMD. Calling this function has the same effect on the source
+   * canvas as any other operation that uses its source image, and canvases
+   * created without preserveDrawingBuffer set to true will be cleared. Only
+   * valid to call in a VRDisplay.requestAnimationFrame callback.
+   */
+  void submitFrame();
+};
+
+typedef (HTMLCanvasElement or
+         OffscreenCanvas) VRSource;
+
+dictionary VRLayerInit {
+  VRSource? source = null;
+
+  sequence<float> leftBounds = [ ];
+  sequence<float> rightBounds = [ ];
+};
+
+interface VRDisplayCapabilities {
+  readonly attribute boolean hasPosition;
+  readonly attribute boolean hasOrientation;
+  readonly attribute boolean hasExternalDisplay;
+  readonly attribute boolean canPresent;
+  readonly attribute unsigned long maxLayers;
+};
+
+enum VREye {
+  "left",
+  "right"
+};
+
+interface VRFieldOfView {
+  readonly attribute double upDegrees;
+  readonly attribute double rightDegrees;
+  readonly attribute double downDegrees;
+  readonly attribute double leftDegrees;
+};
+
+interface VRPose {
+  readonly attribute Float32Array? position;
+  readonly attribute Float32Array? linearVelocity;
+  readonly attribute Float32Array? linearAcceleration;
+
+  readonly attribute Float32Array? orientation;
+  readonly attribute Float32Array? angularVelocity;
+  readonly attribute Float32Array? angularAcceleration;
+};
+
+[Constructor]
+interface VRFrameData {
+  readonly attribute DOMHighResTimeStamp timestamp;
+
+  readonly attribute Float32Array leftProjectionMatrix;
+  readonly attribute Float32Array leftViewMatrix;
+
+  readonly attribute Float32Array rightProjectionMatrix;
+  readonly attribute Float32Array rightViewMatrix;
+
+  readonly attribute VRPose pose;
+};
+
+interface VREyeParameters {
+  readonly attribute Float32Array offset;
+
+  [SameObject] readonly attribute VRFieldOfView fieldOfView;
+
+  readonly attribute unsigned long renderWidth;
+  readonly attribute unsigned long renderHeight;
+};
+
+interface VRStageParameters {
+  readonly attribute Float32Array sittingToStandingTransform;
+
+  readonly attribute float sizeX;
+  readonly attribute float sizeZ;
+};
+
+partial interface Navigator {
+  Promise<sequence<VRDisplay>> getVRDisplays();
+  readonly attribute FrozenArray<VRDisplay> activeVRDisplays;
+};
+
+enum VRDisplayEventReason {
+  "mounted",
+  "navigation",
+  "requested",
+  "unmounted"
+};
+
+[Constructor(DOMString type, VRDisplayEventInit eventInitDict)]
+interface VRDisplayEvent : Event {
+  readonly attribute VRDisplay display;
+  readonly attribute VRDisplayEventReason? reason;
+};
+
+dictionary VRDisplayEventInit : EventInit {
+  required VRDisplay display;
+  VRDisplayEventReason reason;
+};
+
+partial interface Window {
+  attribute EventHandler onvrdisplayconnect;
+  attribute EventHandler onvrdisplaydisconnect;
+  attribute EventHandler onvrdisplayactivate;
+  attribute EventHandler onvrdisplaydeactivate;
+  attribute EventHandler onvrdisplayblur;
+  attribute EventHandler onvrdisplayfocus;
+  attribute EventHandler onvrdisplaypresentchange;
+  attribute EventHandler onvrdisplaypointerrestricted;
+  attribute EventHandler onvrdisplaypointerunrestricted;
+};
+
+partial interface Gamepad {
+  readonly attribute unsigned long displayId;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -488,6 +488,11 @@
         "title": "Web Speech API"
     },
     {
+        "url": "https://immersive-web.github.io/webvr/spec/1.1/",
+        "title": "WebVR",
+        "deprecated": true
+    },
+    {
         "url": "https://www.w3.org/TR/webvtt1/",
         "title": "WebVTT"
     },


### PR DESCRIPTION
https://immersive-web.github.io/webvr/spec/1.1/

>Development of the WebVR API has halted in favor of being replaced the WebXR Device API. Several browsers will continue to support this version of the API in the meantime.

It's deprecated in favor of WebXR but still supported by major browsers.

Fixes Microsoft/TypeScript#18482