### PR TITLE
Make Document#documentElement non-null

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4016,7 +4016,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
     /**
      * Returns the head element.
      */
-    readonly head: HTMLHeadElement | null;
+    readonly head: HTMLHeadElement;
     readonly hidden: boolean;
     /**
      * Retrieves a collection, in source order, of img objects in the document.
@@ -4046,7 +4046,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
     /**
      * Contains information about the current URL.
      */
-    location: Location | null;
+    location: Location;
     onfullscreenchange: ((this: Document, ev: Event) => any) | null;
     onfullscreenerror: ((this: Document, ev: Event) => any) | null;
     /**

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3984,7 +3984,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
     /**
      * Gets a reference to the root node of the document.
      */
-    readonly documentElement: HTMLElement | null;
+    readonly documentElement: HTMLElement;
     /**
      * Returns document's URL.
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -441,6 +441,9 @@
                             "override-type": "HTMLElement",
                             "nullable": false
                         },
+                        "head": {
+                            "nullable": false
+                        },
                         "anchors": {
                             "name": "anchors",
                             "override-type": "HTMLCollectionOf<HTMLAnchorElement>"
@@ -477,7 +480,8 @@
                             "override-type": "HTMLCollectionOf<HTMLScriptElement>"
                         },
                         "location": {
-                            "read-only": 0
+                            "read-only": 0,
+                            "nullable": false
                         },
                         "body": {
                             "nullable": false

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -438,7 +438,8 @@
                     "property": {
                         "documentElement": {
                             "name": "documentElement",
-                            "override-type": "HTMLElement"
+                            "override-type": "HTMLElement",
+                            "nullable": false
                         },
                         "anchors": {
                             "name": "anchors",


### PR DESCRIPTION
Fixes an issue similar to #558.
Discovered in `puppeteer` on DefinitelyTyped.