### PR TITLE
Add additional types to 'resolve' argument in 'evaluate' method

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4329,7 +4329,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      */
     elementFromPoint(x: number, y: number): Element | null;
     elementsFromPoint(x: number, y: number): Element[];
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult;
     /**
      * Executes a command on the current document, current selection, or the given range.
      * @param commandId String that specifies the command to execute. This command can be any of the command identifiers that can be executed in script.
@@ -16752,7 +16752,7 @@ declare var XMLSerializer: {
 interface XPathEvaluator {
     createExpression(expression: string, resolver: XPathNSResolver): XPathExpression;
     createNSResolver(nodeResolver?: Node): XPathNSResolver;
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult;
 }
 
 declare var XPathEvaluator: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -398,7 +398,7 @@
                         "evaluate": {
                             "name": "evaluate",
                             "override-signatures": [
-                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"
+                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult"
                             ]
                         },
                         "getElementsByTagNameNS": {
@@ -1362,7 +1362,7 @@
                         "evaluate": {
                             "name": "evaluate",
                             "override-signatures": [
-                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"
+                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult"
                             ]
                         }
                     }


### PR DESCRIPTION
Fixes [#26437](https://github.com/Microsoft/TypeScript/issues/26437)

> Note: The parameter resolver of the method XPathEvaluator.evaluate is specified as an object that implements the XPathNSResolver interface. ECMAScript users can also pass to this method a function which returns a String and takes a String parameter instead of the resolver parameter.

