### PR TITLE
Update Web Animations keyframe definitions

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -201,7 +201,7 @@ interface ComputedEffectTiming extends EffectTiming {
 }
 
 interface ComputedKeyframe extends Record<keyof CSSStyleDeclaration, string> {
-    composite?: CompositeOperation | null;
+    composite?: CompositeOperationOrAuto;
     computedOffset?: number;
     easing?: string;
     offset?: number | null;
@@ -567,7 +567,7 @@ interface KeyboardEventInit extends EventModifierInit {
 }
 
 interface Keyframe extends Record<keyof CSSStyleDeclaration, string> {
-    composite?: CompositeOperation | null;
+    composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
 }
@@ -922,7 +922,7 @@ interface PromiseRejectionEventInit extends EventInit {
 }
 
 interface PropertyIndexedKeyframes extends Record<keyof CSSStyleDeclaration, string | string[]> {
-    composite?: CompositeOperation | (CompositeOperation | null)[];
+    composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
 }
@@ -17648,6 +17648,7 @@ type ChannelCountMode = "max" | "clamped-max" | "explicit";
 type ChannelInterpretation = "speakers" | "discrete";
 type ClientTypes = "window" | "worker" | "sharedworker" | "all";
 type CompositeOperation = "replace" | "add" | "accumulate";
+type CompositeOperationOrAuto = "replace" | "add" | "accumulate" | "auto";
 type DirectionSetting = "" | "rl" | "lr";
 type DisplayCaptureSurfaceType = "monitor" | "window" | "application" | "browser";
 type DistanceModelType = "linear" | "inverse" | "exponential";

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -200,11 +200,12 @@ interface ComputedEffectTiming extends EffectTiming {
     progress?: number | null;
 }
 
-interface ComputedKeyframe extends Record<keyof CSSStyleDeclaration, string> {
-    composite?: CompositeOperationOrAuto;
-    computedOffset?: number;
-    easing?: string;
-    offset?: number | null;
+interface ComputedKeyframe {
+    composite: CompositeOperationOrAuto;
+    computedOffset: number;
+    easing: string;
+    offset: number | null;
+    [property: string]: string | number | null | undefined;
 }
 
 interface ConfirmSiteSpecificExceptionsInformation extends ExceptionInformation {
@@ -566,10 +567,11 @@ interface KeyboardEventInit extends EventModifierInit {
     repeat?: boolean;
 }
 
-interface Keyframe extends Record<keyof CSSStyleDeclaration, string> {
+interface Keyframe {
     composite?: CompositeOperationOrAuto;
     easing?: string;
     offset?: number | null;
+    [property: string]: string | number | null | undefined;
 }
 
 interface KeyframeAnimationOptions extends KeyframeEffectOptions {
@@ -921,10 +923,11 @@ interface PromiseRejectionEventInit extends EventInit {
     reason?: any;
 }
 
-interface PropertyIndexedKeyframes extends Record<keyof CSSStyleDeclaration, string | string[]> {
+interface PropertyIndexedKeyframes {
     composite?: CompositeOperationOrAuto | CompositeOperationOrAuto[];
     easing?: string | string[];
     offset?: number | (number | null)[];
+    [property: string]: string | string[] | number | null | (number | null)[] | undefined;
 }
 
 interface PushSubscriptionJSON {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2524,6 +2524,29 @@ declare var TextEncoder: {
     new(): TextEncoder;
 };
 
+interface TextMetrics {
+    readonly actualBoundingBoxAscent: number;
+    readonly actualBoundingBoxDescent: number;
+    readonly actualBoundingBoxLeft: number;
+    readonly actualBoundingBoxRight: number;
+    readonly alphabeticBaseline: number;
+    readonly emHeightAscent: number;
+    readonly emHeightDescent: number;
+    readonly fontBoundingBoxAscent: number;
+    readonly fontBoundingBoxDescent: number;
+    readonly hangingBaseline: number;
+    /**
+     * Returns the measurement described below.
+     */
+    readonly ideographicBaseline: number;
+    readonly width: number;
+}
+
+declare var TextMetrics: {
+    prototype: TextMetrics;
+    new(): TextMetrics;
+};
+
 interface URL {
     hash: string;
     host: string;

--- a/inputfiles/idl/HTML - Canvas.widl
+++ b/inputfiles/idl/HTML - Canvas.widl
@@ -214,7 +214,7 @@ interface CanvasPattern {
   void setTransform(optional DOMMatrix2DInit transform);
 };
 
-[Exposed=Window]
+[Exposed=(Window,Worker)]
 interface TextMetrics {
   // x-direction
   readonly attribute double width; // advance width
@@ -295,7 +295,9 @@ OffscreenCanvasRenderingContext2D includes CanvasShadowStyles;
 OffscreenCanvasRenderingContext2D includes CanvasFilters;
 OffscreenCanvasRenderingContext2D includes CanvasRect;
 OffscreenCanvasRenderingContext2D includes CanvasDrawPath;
+OffscreenCanvasRenderingContext2D includes CanvasText;
 OffscreenCanvasRenderingContext2D includes CanvasDrawImage;
 OffscreenCanvasRenderingContext2D includes CanvasImageData;
 OffscreenCanvasRenderingContext2D includes CanvasPathDrawingStyles;
+OffscreenCanvasRenderingContext2D includes CanvasTextDrawingStyles;
 OffscreenCanvasRenderingContext2D includes CanvasPath;

--- a/inputfiles/idl/HTML - DOM.widl
+++ b/inputfiles/idl/HTML - DOM.widl
@@ -83,7 +83,7 @@ interface HTMLUnknownElement : HTMLElement { };
 
 interface mixin HTMLOrSVGElement {
   [SameObject] readonly attribute DOMStringMap dataset;
-  attribute DOMString nonce;
+  attribute DOMString nonce; // intentionally no [CEReactions]
 
   [CEReactions] attribute long tabIndex;
   void focus(optional FocusOptions options);

--- a/inputfiles/idl/HTML - Form elements.widl
+++ b/inputfiles/idl/HTML - Form elements.widl
@@ -108,7 +108,7 @@ interface HTMLTextAreaElement : HTMLElement {
 
   readonly attribute DOMString type;
   [CEReactions] attribute DOMString defaultValue;
-  [CEReactions] attribute [TreatNullAs=EmptyString] DOMString value;
+  attribute [TreatNullAs=EmptyString] DOMString value;
   readonly attribute unsigned long textLength;
 
   readonly attribute boolean willValidate;

--- a/inputfiles/idl/Web Animations.widl
+++ b/inputfiles/idl/Web Animations.widl
@@ -93,22 +93,22 @@ interface KeyframeEffect : AnimationEffect {
 };
 
 dictionary BaseComputedKeyframe {
-     double?             offset = null;
-     double              computedOffset;
-     DOMString           easing = "linear";
-     CompositeOperation? composite = null;
+     double?                  offset = null;
+     double                   computedOffset;
+     DOMString                easing = "linear";
+     CompositeOperationOrAuto composite = "auto";
 };
 
 dictionary BasePropertyIndexedKeyframe {
     (double? or sequence<double?>)                         offset = [];
     (DOMString or sequence<DOMString>)                     easing = [];
-    (CompositeOperation? or sequence<CompositeOperation?>) composite = [];
+    (CompositeOperationOrAuto or sequence<CompositeOperationOrAuto>) composite = [];
 };
 
 dictionary BaseKeyframe {
-    double?             offset = null;
-    DOMString           easing = "linear";
-    CompositeOperation? composite = null;
+    double?                  offset = null;
+    DOMString                easing = "linear";
+    CompositeOperationOrAuto composite = "auto";
 };
 
 dictionary KeyframeEffectOptions : EffectTiming {
@@ -119,6 +119,8 @@ dictionary KeyframeEffectOptions : EffectTiming {
 enum IterationCompositeOperation {"replace", "accumulate"};
 
 enum CompositeOperation {"replace", "add", "accumulate"};
+
+enum CompositeOperationOrAuto {"replace", "add", "accumulate", "auto"};
 
 interface mixin Animatable {
     Animation           animate (object? keyframes,

--- a/inputfiles/idl/WebRTC.widl
+++ b/inputfiles/idl/WebRTC.widl
@@ -100,7 +100,7 @@ interface RTCPeerConnection : EventTarget  {
     readonly        attribute RTCSessionDescription?    remoteDescription;
     readonly        attribute RTCSessionDescription?    currentRemoteDescription;
     readonly        attribute RTCSessionDescription?    pendingRemoteDescription;
-    Promise<void>                      addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate);
+    Promise<void>                      addIceCandidate (RTCIceCandidateInit candidate);
     readonly        attribute RTCSignalingState         signalingState;
     readonly        attribute RTCIceGatheringState      iceGatheringState;
     readonly        attribute RTCIceConnectionState     iceConnectionState;
@@ -124,7 +124,7 @@ partial interface RTCPeerConnection {
     Promise<void> setLocalDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
     Promise<void> createAnswer (RTCSessionDescriptionCallback successCallback, RTCPeerConnectionErrorCallback failureCallback);
     Promise<void> setRemoteDescription (RTCSessionDescriptionInit description, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
-    Promise<void> addIceCandidate ((RTCIceCandidateInit or RTCIceCandidate) candidate, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
+    Promise<void> addIceCandidate (RTCIceCandidateInit candidate, VoidFunction successCallback, RTCPeerConnectionErrorCallback failureCallback);
 };
 
 callback RTCPeerConnectionErrorCallback = void (DOMException error);

--- a/inputfiles/knownTypes.json
+++ b/inputfiles/knownTypes.json
@@ -14,6 +14,7 @@
         "ClientData",
         "ClientQueryOptions",
         "ClientTypes",
+        "CompositeOperationOrAuto",
         "ComputedKeyframe",
         "ConstrainBoolean",
         "ConstrainDOMString",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2527,15 +2527,37 @@
             },
             "BaseKeyframe": {
                 "name": "Keyframe",
-                "extends": "Record<keyof CSSStyleDeclaration, string>"
+                "override-index-signatures": [
+                    "[property: string]: string | number | null | undefined"
+                ]
             },
             "BasePropertyIndexedKeyframe": {
                 "name": "PropertyIndexedKeyframes",
-                "extends": "Record<keyof CSSStyleDeclaration, string | string[]>"
+                "override-index-signatures": [
+                    "[property: string]: string | string[] | number | null | (number | null)[] | undefined"
+                ]
             },
             "BaseComputedKeyframe": {
                 "name": "ComputedKeyframe",
-                "extends": "Record<keyof CSSStyleDeclaration, string>"
+                "members": {
+                    "member": {
+                        "offset": {
+                            "required": 1
+                        },
+                        "computedOffset": {
+                            "required": 1
+                        },
+                        "easing": {
+                            "required": 1
+                        },
+                        "composite": {
+                            "required": 1
+                        }
+                    }
+                },
+                "override-index-signatures": [
+                    "[property: string]: string | number | null | undefined"
+                ]
             }
         }
     },

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -1028,6 +1028,9 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
                 .sort(compareName)
                 .forEach(m => printer.printLine(`${m.name}${m.required === 1 ? "" : "?"}: ${convertDomTypeToTsType(m)};`));
         }
+        if (dict["override-index-signatures"]) {
+            dict["override-index-signatures"]!.forEach(s => printer.printLine(`${s};`));
+        }
         printer.decreaseIndent();
         printer.printLine("}");
         printer.printLine("");

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -211,6 +211,7 @@ export interface Dictionary {
     members: {
         member: Record<string, Member>;
     }
+    "override-index-signatures"?: string[];
     specs?: string;
     "type-parameters"?: TypeParameter[];
 }


### PR DESCRIPTION
This is an initial attempt at fixing https://github.com/Microsoft/TypeScript/issues/26073

It should possibly be split up into several patches/PRs but I wanted to get some initial feedback first.

A few notes:
* I've included the update to the `CompositeOperationOrAuto` type which was [recent spec change](https://github.com/w3c/csswg-drafts/commit/ced6b5aac02e0e021001f10e4d63e03456686dad), simply because it makes the index type for `PropertyIndexedKeyframes` a little more sane.
* I have no idea how to represent this sort of open dictionary with a few typed keys in TypeScript so this approach might be completely wrong. Bear in mind that with the arrival of animatable custom properties the set of properties that can be specified on a keyframe is essentially open-ended.
* Allowing `number` for the property values is actually ok since WebIDL will perform `ToString` on passed-in numbers so it is actually quite valid (and common) to specify a keyframe as `{ opacity: 0 }` and let WebIDL turn the zero into a string.
* I've made the members of `ComputedKeyframe` required since these dictionary objects are only returned from `getKeyframes()` where they are guaranteed to be filled-in.

Edit: Updated the example about stringification from `{ offset: 0 }` to `{ opacity: 0 }` (since that's what I originally meant to say, particularly since `offset` is actually supposed to be a number).