### PR TITLE
Allow function as resolver in document.evaluate

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4329,7 +4329,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      */
     elementFromPoint(x: number, y: number): Element | null;
     elementsFromPoint(x: number, y: number): Element[];
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult;
     /**
      * Executes a command on the current document, current selection, or the given range.
      * @param commandId String that specifies the command to execute. This command can be any of the command identifiers that can be executed in script.

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -398,7 +398,7 @@
                         "evaluate": {
                             "name": "evaluate",
                             "override-signatures": [
-                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"
+                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string) | null, type: number, result: XPathResult | null): XPathResult"
                             ]
                         },
                         "getElementsByTagNameNS": {


### PR DESCRIPTION
Add function reference to `document.evaluate` signature.

Closes Microsoft/TypeScript#26437