### PR TITLE
Override XPathNSResolver and document's evaluate method

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4329,7 +4329,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      */
     elementFromPoint(x: number, y: number): Element | null;
     elementsFromPoint(x: number, y: number): Element[];
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string | null) | null, type: number, result: XPathResult | null): XPathResult;
     /**
      * Executes a command on the current document, current selection, or the given range.
      * @param commandId String that specifies the command to execute. This command can be any of the command identifiers that can be executed in script.
@@ -16752,7 +16752,7 @@ declare var XMLSerializer: {
 interface XPathEvaluator {
     createExpression(expression: string, resolver: XPathNSResolver): XPathExpression;
     createNSResolver(nodeResolver?: Node): XPathNSResolver;
-    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult;
+    evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string | null) | null, type: number, result: XPathResult | null): XPathResult;
 }
 
 declare var XPathEvaluator: {
@@ -16770,7 +16770,7 @@ declare var XPathExpression: {
 };
 
 interface XPathNSResolver {
-    lookupNamespaceURI(prefix: string): string;
+    lookupNamespaceURI(prefix: string): string | null;
 }
 
 declare var XPathNSResolver: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -204,6 +204,17 @@
     },
     "interfaces": {
         "interface": {
+            "XPathNSResolver": {
+                "methods": {
+                    "method": {
+                        "lookupNamespaceURI": {
+                            "override-signatures": [
+                                "lookupNamespaceURI(prefix: string): string | null"
+                            ]
+                        }
+                    }
+                }
+            },
             "CryptoKey": {
                 "properties": {
                     "property": {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -409,7 +409,7 @@
                         "evaluate": {
                             "name": "evaluate",
                             "override-signatures": [
-                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"
+                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string | null) | null, type: number, result: XPathResult | null): XPathResult"
                             ]
                         },
                         "getElementsByTagNameNS": {
@@ -1373,7 +1373,7 @@
                         "evaluate": {
                             "name": "evaluate",
                             "override-signatures": [
-                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | null, type: number, result: XPathResult | null): XPathResult"
+                                "evaluate(expression: string, contextNode: Node, resolver: XPathNSResolver | ((prefix: string) => string | null) | null, type: number, result: XPathResult | null): XPathResult"
                             ]
                         }
                     }


### PR DESCRIPTION
According to the issue discussed in https://github.com/Microsoft/TypeScript/issues/26437 `XPathNSResolver`'s property `lookupNamespaceURI` should also return `null` and `Document`'s `evaluate` method should accept  _"a function which returns a String and takes a String parameter instead of the resolver parameter."_ (and also return `null` if needed).

I had originally created the PR in https://github.com/Microsoft/TypeScript/pull/27592, my bad, this is the correct place to change.