### PR TITLE
Remove wheelDelta fields from WheelEvent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16179,9 +16179,6 @@ interface WheelEvent extends MouseEvent {
     readonly deltaX: number;
     readonly deltaY: number;
     readonly deltaZ: number;
-    readonly wheelDelta: number;
-    readonly wheelDeltaX: number;
-    readonly wheelDeltaY: number;
     getCurrentPoint(element: Element): void;
     initWheelEvent(typeArg: string, canBubbleArg: boolean, cancelableArg: boolean, viewArg: Window, detailArg: number, screenXArg: number, screenYArg: number, clientXArg: number, clientYArg: number, buttonArg: number, relatedTargetArg: EventTarget, modifiersListArg: string, deltaXArg: number, deltaYArg: number, deltaZArg: number, deltaMode: number): void;
     readonly DOM_DELTA_LINE: number;

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -193,6 +193,15 @@
                         "ontouchstart": null
                     }
                 }
+            },
+			"WheelEvent": {
+                "properties": {
+                    "property": {
+                        "wheelDelta": null,
+                        "wheelDeltaX": null,
+                        "wheelDeltaY": null
+                    }
+                }
             }
         }
     },

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -194,7 +194,7 @@
                     }
                 }
             },
-			"WheelEvent": {
+            "WheelEvent": {
                 "properties": {
                     "property": {
                         "wheelDelta": null,


### PR DESCRIPTION
Microsoft/TypeScript#27886

These fields originated from the deprecated [MouseWheelEvent](https://developer.mozilla.org/en-US/docs/Web/API/MouseWheelEvent) type, which is currently defined as `type MouseWheelEvent = WheelEvent;`.

I couldn't find any references to this type so it might make sense to remove it, since it already is incorrect and will be broken even more through this fix.
`onmousewheel: ((this: Window, ev: Event) => any) | null;`
The corresponding listeners simply use `Event`.

If there is any reason to keep MouseEventWheel, I think creating an extra interface for it would be the best solution. Feedback is welcome.
