### PR TITLE
add referrerPolicy to HTMLIFrameElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -6504,6 +6504,7 @@ interface HTMLIFrameElement extends HTMLElement, GetSVGDocument {
      * Sets or retrieves the frame name.
      */
     name: string;
+    readonly referrerPolicy: ReferrerPolicy;
     readonly sandbox: DOMTokenList;
     /**
      * Sets or retrieves whether the frame can be scrolled.

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -808,6 +808,11 @@
                         "srcdoc": {
                             "name": "srcdoc",
                             "override-type": "string"
+                        },
+                        "referrerPolicy": {
+                            "name": "referrerPolicy",
+                            "read-only": 1,
+                            "override-type": "ReferrerPolicy"
                         }
                     }
                 }


### PR DESCRIPTION
Hi, first time contributor, so beware.

Trying to add the missing "referrerPolicy" attribute to iframe:
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-referrerpolicy

Would like to check a few things:

- Can someone confirm referrerPolicy should be "readonly"? I'm not 100% sure how to determine this, following the "sandbox" example.
- string or ReferrerPolicy type? (In other use-cases, referrerPolicy is mostly defined as "string" whereas there is one example usage of type ReferrerPolicy. The type has the correct values though)
- Should I open a bug on main TS repository referencing this, or is this fine as such?

Thanks.