### PR TITLE
Add caret(Range/Position)FromPoint to DocumentOrShadowDOM

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4558,6 +4558,9 @@ interface DocumentOrShadowRoot {
      * Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.
      */
     readonly styleSheets: StyleSheetList;
+    caretPositionFromPoint(x: number, y: number): CaretPosition | null;
+    /** @deprecated */
+    caretRangeFromPoint(x: number, y: number): Range;
     elementFromPoint(x: number, y: number): Element | null;
     elementsFromPoint(x: number, y: number): Element[];
     getSelection(): Selection | null;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1118,6 +1118,19 @@
                             "override-signatures": [
                                 "elementsFromPoint(x: number, y: number): Element[]"
                             ]
+                        },
+                        "caretRangeFromPoint": {
+                            "name": "caretRangeFromPoint",
+                            "deprecated": 1,
+                            "override-signatures": [
+                                "caretRangeFromPoint(x: number, y: number): Range"
+                            ]
+                        },
+                        "caretPositionFromPoint": {
+                            "name": "caretPositionFromPoint",
+                            "override-signatures": [
+                                "caretPositionFromPoint(x: number, y: number): CaretPosition | null"
+                            ]
                         }
                     }
                 },


### PR DESCRIPTION
This adds `caretRangeFromPoint` and `caretPositionFromPoint` to `DocumentOrShadowDOM` in `dom.generated.d.ts`.

I tried to remove them from `Document` as well, since that inherits from `DocumentOrShadowDOM`, but doing that caused all kinds of changes to the generated code that I couldn't explain, so I didn't feel qualified to touch that and left the existing properties on the `Document` class.

Issue https://github.com/Microsoft/TypeScript/issues/28155#issuecomment-433487385