### PR TITLE
Relocate Identity for WebRTC spec

### DIFF
--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -163,7 +163,7 @@
         "title": "HTML - User interaction"
     },
     {
-        "url": "https://w3c.github.io/webrtc-pc/identity.html",
+        "url": "https://w3c.github.io/webrtc-identity/",
         "title": "Identity for WebRTC"
     },
     {


### PR DESCRIPTION
It was once in WebRTC repo but is later separated. 