### PR TITLE
Allow fetching each spec

### DIFF
--- a/src/fetcher.ts
+++ b/src/fetcher.ts
@@ -3,7 +3,7 @@ import * as path from "path";
 import fetch from "node-fetch";
 import { JSDOM } from "jsdom";
 
-fetchIDLs();
+fetchIDLs(process.argv.slice(2));
 
 interface IDLSource {
     url: string;
@@ -19,8 +19,9 @@ const idlSelector = [
 
 const cssPropSelector = "dfn.css[data-dfn-type=property]";
 
-async function fetchIDLs() {
-    const idlSources = require("../inputfiles/idlSources.json") as IDLSource[];
+async function fetchIDLs(filter: string[]) {
+    const idlSources = (require("../inputfiles/idlSources.json") as IDLSource[])
+        .filter(source => !filter.length || filter.includes(source.title));
     await Promise.all(idlSources.map(async source => {
         const { idl, comments } = await fetchIDL(source);
         fs.writeFileSync(path.join(__dirname, `../inputfiles/idl/${source.title}.widl`), idl + '\n');


### PR DESCRIPTION
`npm run fetch` takes too much time to debug or causes too much changes to create a single PR, as it always fetches every registered spec.

This PR allows `npm run fetch -- (specTitle1) (specTitle2), (...)` so that contributors can open a PR more easily.