### PR TITLE
Change `Event.srcElement` type to `EventTarget` and expose it to Worker

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4942,7 +4942,7 @@ interface Event {
     readonly isTrusted: boolean;
     returnValue: boolean;
     /** @deprecated */
-    readonly srcElement: Element | null;
+    readonly srcElement: EventTarget | null;
     /**
      * Returns the object to which event is dispatched (its target).
      */

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1020,6 +1020,8 @@ interface Event {
      */
     readonly isTrusted: boolean;
     returnValue: boolean;
+    /** @deprecated */
+    readonly srcElement: EventTarget | null;
     /**
      * Returns the object to which event is dispatched (its target).
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2227,8 +2227,7 @@
                 "properties": {
                     "property": {
                         "srcElement": {
-                            "exposed": "Window",
-                            "type": "Element",
+                            "exposed": "Window Worker",
                             "nullable": 1,
                             "deprecated": 1
                         }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2227,7 +2227,6 @@
                 "properties": {
                     "property": {
                         "srcElement": {
-                            "exposed": "Window Worker",
                             "nullable": 1,
                             "deprecated": 1
                         }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2227,7 +2227,6 @@
                 "properties": {
                     "property": {
                         "srcElement": {
-                            "nullable": 1,
                             "deprecated": 1
                         }
                     }


### PR DESCRIPTION
This PR changes `Event.srcElement` type to `EventTarget` and exposes it to Worker. Accepting this PR should close https://github.com/Microsoft/TypeScript/issues/28252, however I would like to hear from @mhegazy first as to why `Element` type was chosen. Maybe there's a specific reason I don't know and now I'm ruining everything :).