### PR TITLE
Return to typescript@next

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1667,9 +1667,9 @@
       }
     },
     "typescript": {
-      "version": "2.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-      "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+      "version": "3.2.0-dev.20181101",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.0-dev.20181101.tgz",
+      "integrity": "sha512-7OL68e1Ab4L5EyKsscjgta0i6tiwzzeYCnmd6sLOJyy0GAvvuNKbtHQlICBhF227z8K0P8r/OQoL32If5So2Cw=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "jsdom": "^11.11.0",
     "node-fetch": "^2.1.1",
     "print-diff": "^0.1.1",
-    "typescript": "^2.9.2",
+    "typescript": "next",
     "webidl2": "^13.0.2"
   }
 }


### PR DESCRIPTION
#556 forced to use TS 2.9.2 because of temporary bug on TS 3.0. This PR reverts it.