### PR TITLE
Fix DocumentOrShadowRoot.fullscreenElement

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4637,6 +4637,7 @@ declare var DocumentFragment: {
 
 interface DocumentOrShadowRoot {
     readonly activeElement: Element | null;
+    readonly fullscreenElement: Element | null;
     /**
      * Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.
      */
@@ -14182,7 +14183,7 @@ declare var ServiceWorkerRegistration: {
     new(): ServiceWorkerRegistration;
 };
 
-interface ShadowRoot extends DocumentOrShadowRoot, DocumentFragment, DocumentOrShadowRoot {
+interface ShadowRoot extends DocumentFragment, DocumentOrShadowRoot {
     readonly host: Element;
     innerHTML: string;
     readonly mode: ShadowRootMode;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -19,6 +19,58 @@
                     ]
                 }
             },
+            "DocumentOrShadowRoot": {
+                "name": "DocumentOrShadowRoot",
+                "methods": {
+                    "method": {
+                        "getSelection": {
+                            "name": "getSelection",
+                            "override-signatures": [
+                                "getSelection(): Selection | null"
+                            ]
+                        },
+                        "elementFromPoint": {
+                            "name": "elementFromPoint",
+                            "override-signatures": [
+                                "elementFromPoint(x: number, y: number): Element | null"
+                            ]
+                        },
+                        "elementsFromPoint": {
+                            "name": "elementsFromPoint",
+                            "override-signatures": [
+                                "elementsFromPoint(x: number, y: number): Element[]"
+                            ]
+                        },
+                        "caretRangeFromPoint": {
+                            "name": "caretRangeFromPoint",
+                            "deprecated": 1,
+                            "override-signatures": [
+                                "caretRangeFromPoint(x: number, y: number): Range"
+                            ]
+                        },
+                        "caretPositionFromPoint": {
+                            "name": "caretPositionFromPoint",
+                            "override-signatures": [
+                                "caretPositionFromPoint(x: number, y: number): CaretPosition | null"
+                            ]
+                        }
+                    }
+                },
+                "properties": {
+                    "property": {
+                        "activeElement": {
+                            "name": "activeElement",
+                            "read-only": 1,
+                            "override-type": "Element | null"
+                        },
+                        "styleSheets": {
+                            "name": "styleSheets",
+                            "read-only": 1,
+                            "override-type": "StyleSheetList"
+                        }
+                    }
+                }
+            },
             "GlobalEventHandlers": {
                 "events": {
                     "event": [
@@ -1104,63 +1156,9 @@
                     }
                 }
             },
-            "DocumentOrShadowRoot": {
-                "name": "DocumentOrShadowRoot",
-                "exposed": "Window",
-                "methods": {
-                    "method": {
-                        "getSelection": {
-                            "name": "getSelection",
-                            "override-signatures": [
-                                "getSelection(): Selection | null"
-                            ]
-                        },
-                        "elementFromPoint": {
-                            "name": "elementFromPoint",
-                            "override-signatures": [
-                                "elementFromPoint(x: number, y: number): Element | null"
-                            ]
-                        },
-                        "elementsFromPoint": {
-                            "name": "elementsFromPoint",
-                            "override-signatures": [
-                                "elementsFromPoint(x: number, y: number): Element[]"
-                            ]
-                        },
-                        "caretRangeFromPoint": {
-                            "name": "caretRangeFromPoint",
-                            "deprecated": 1,
-                            "override-signatures": [
-                                "caretRangeFromPoint(x: number, y: number): Range"
-                            ]
-                        },
-                        "caretPositionFromPoint": {
-                            "name": "caretPositionFromPoint",
-                            "override-signatures": [
-                                "caretPositionFromPoint(x: number, y: number): CaretPosition | null"
-                            ]
-                        }
-                    }
-                },
-                "properties": {
-                    "property": {
-                        "activeElement": {
-                            "name": "activeElement",
-                            "read-only": 1,
-                            "override-type": "Element | null"
-                        },
-                        "styleSheets": {
-                            "name": "styleSheets",
-                            "read-only": 1,
-                            "override-type": "StyleSheetList"
-                        }
-                    }
-                },
-                "no-interface-object": "1"
-            },
             "ShadowRoot": {
                 "name": "ShadowRoot",
-                "extends": "DocumentOrShadowRoot, DocumentFragment",
+                "extends": "DocumentFragment",
                 "exposed": "Window",
                 "properties": {
                     "property": {

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1,6 +1,15 @@
 {
     "mixins": {
         "mixin": {
+            "DocumentOrShadowRoot": {
+                "properties": {
+                    "property": {
+                        "styleSheets": {
+                            "comment": "/**\r\n * Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.\r\n */"
+                        }
+                    }
+                }
+            },
             "GlobalEventHandlers": {
                 "properties": {
                     "property": {
@@ -660,15 +669,6 @@
                         },
                         "type": {
                             "comment": "/**\r\n * Gets or sets the MIME type of a media resource.\r\n */"
-                        }
-                    }
-                }
-            },
-            "DocumentOrShadowRoot": {
-                "properties": {
-                    "property": {
-                        "styleSheets": {
-                            "comment": "/**\r\n * Retrieves a collection of styleSheet objects representing the style sheets that correspond to each instance of a link or style object in the document.\r\n */"
                         }
                     }
                 }


### PR DESCRIPTION
DocumentOrShadowRoot needs to be a mixin, not an interface,
to allow us to extend it without addedTypes.json overwriting it.

Fixes issue #551