### PR TITLE
Auto emit comments for iteration methods

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1959,6 +1959,11 @@ declare var AudioParam: {
 };
 
 interface AudioParamMap {
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: AudioParam, key: string, parent: AudioParamMap) => void, thisArg?: any): void;
 }
 
@@ -3757,6 +3762,11 @@ interface DOMTokenList {
      */
     supports(token: string): boolean;
     toggle(token: string, force?: boolean): boolean;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: string, key: number, parent: DOMTokenList) => void, thisArg?: any): void;
     [index: number]: string;
 }
@@ -5147,6 +5157,11 @@ interface FormData {
     getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
     set(name: string, value: string | Blob, fileName?: string): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 
@@ -8615,6 +8630,11 @@ interface Headers {
     get(name: string): string | null;
     has(name: string): boolean;
     set(name: string, value: string): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
 }
 
@@ -10519,6 +10539,11 @@ interface NodeList {
      * element = collection[index]
      */
     item(index: number): Node | null;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: Node, key: number, parent: NodeList) => void, thisArg?: any): void;
     [index: number]: Node;
 }
@@ -10531,6 +10556,11 @@ declare var NodeList: {
 interface NodeListOf<TNode extends Node> extends NodeList {
     length: number;
     item(index: number): TNode;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: any): void;
     [index: number]: TNode;
 }
@@ -11732,6 +11762,11 @@ declare var RTCStatsProvider: {
 };
 
 interface RTCStatsReport {
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: any, key: string, parent: RTCStatsReport) => void, thisArg?: any): void;
 }
 
@@ -14984,6 +15019,11 @@ interface URLSearchParams {
      */
     set(name: string, value: string): void;
     sort(): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }
 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4515,9 +4515,6 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      * @param content The text and HTML tags to write.
      */
     writeln(...text: string[]): void;
-    /**
-     * Returns an object representing the current selection of the document that is loaded into the object displaying a webpage.
-     */
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: Document, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -10522,11 +10519,6 @@ interface NodeList {
      * element = collection[index]
      */
     item(index: number): Node | null;
-    /**
-     * Performs the specified action for each node in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-     */
     forEach(callbackfn: (value: Node, key: number, parent: NodeList) => void, thisArg?: any): void;
     [index: number]: Node;
 }
@@ -10539,11 +10531,6 @@ declare var NodeList: {
 interface NodeListOf<TNode extends Node> extends NodeList {
     length: number;
     item(index: number): TNode;
-    /**
-     * Performs the specified action for each node in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
-     */
     forEach(callbackfn: (value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: any): void;
     [index: number]: TNode;
 }

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1961,8 +1961,8 @@ declare var AudioParam: {
 interface AudioParamMap {
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: AudioParam, key: string, parent: AudioParamMap) => void, thisArg?: any): void;
 }
@@ -3764,8 +3764,8 @@ interface DOMTokenList {
     toggle(token: string, force?: boolean): boolean;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: string, key: number, parent: DOMTokenList) => void, thisArg?: any): void;
     [index: number]: string;
@@ -5159,8 +5159,8 @@ interface FormData {
     set(name: string, value: string | Blob, fileName?: string): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
@@ -8632,8 +8632,8 @@ interface Headers {
     set(name: string, value: string): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
 }
@@ -10541,8 +10541,8 @@ interface NodeList {
     item(index: number): Node | null;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: Node, key: number, parent: NodeList) => void, thisArg?: any): void;
     [index: number]: Node;
@@ -10558,8 +10558,8 @@ interface NodeListOf<TNode extends Node> extends NodeList {
     item(index: number): TNode;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: any): void;
     [index: number]: TNode;
@@ -11764,8 +11764,8 @@ declare var RTCStatsProvider: {
 interface RTCStatsReport {
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: any, key: string, parent: RTCStatsReport) => void, thisArg?: any): void;
 }
@@ -15021,8 +15021,8 @@ interface URLSearchParams {
     sort(): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -31,8 +31,17 @@ interface DOMStringList {
 
 interface DOMTokenList {
     [Symbol.iterator](): IterableIterator<string>;
+    /**
+     * Returns an iterator allowing to go through all key/value pairs contained in this object.
+     */
     entries(): IterableIterator<[number, string]>;
+    /**
+     * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
+     */
     keys(): IterableIterator<number>;
+    /**
+     * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
+     */
     values(): IterableIterator<string>;
 }
 
@@ -47,15 +56,15 @@ interface FileList {
 interface FormData {
     [Symbol.iterator](): IterableIterator<[string, FormDataEntryValue]>;
     /**
-     * Returns an array of key, value pairs for every entry in the list.
+     * Returns an iterator allowing to go through all key/value pairs contained in this object.
      */
     entries(): IterableIterator<[string, FormDataEntryValue]>;
     /**
-     * Returns a list of keys in the list.
+     * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
      */
     keys(): IterableIterator<string>;
     /**
-     * Returns a list of values in the list.
+     * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
      */
     values(): IterableIterator<FormDataEntryValue>;
 }
@@ -111,15 +120,15 @@ interface NamedNodeMap {
 interface NodeList {
     [Symbol.iterator](): IterableIterator<Node>;
     /**
-     * Returns an array of key, value pairs for every entry in the list.
+     * Returns an iterator allowing to go through all key/value pairs contained in this object.
      */
     entries(): IterableIterator<[number, Node]>;
     /**
-     * Returns an list of keys in the list.
+     * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
      */
     keys(): IterableIterator<number>;
     /**
-     * Returns an list of values in the list.
+     * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
      */
     values(): IterableIterator<Node>;
 }
@@ -127,15 +136,15 @@ interface NodeList {
 interface NodeListOf<TNode extends Node> {
     [Symbol.iterator](): IterableIterator<TNode>;
     /**
-     * Returns an array of key, value pairs for every entry in the list.
+     * Returns an iterator allowing to go through all key/value pairs contained in this object.
      */
     entries(): IterableIterator<[number, TNode]>;
     /**
-     * Returns an list of keys in the list.
+     * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
      */
     keys(): IterableIterator<number>;
     /**
-     * Returns an list of values in the list.
+     * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
      */
     values(): IterableIterator<TNode>;
 }
@@ -198,15 +207,15 @@ interface TouchList {
 interface URLSearchParams {
     [Symbol.iterator](): IterableIterator<[string, string]>;
     /**
-     * Returns an array of key, value pairs for every entry in the search params.
+     * Returns an iterator allowing to go through all key/value pairs contained in this object.
      */
     entries(): IterableIterator<[string, string]>;
     /**
-     * Returns a list of keys in the search params.
+     * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.
      */
     keys(): IterableIterator<string>;
     /**
-     * Returns a list of values in the search params.
+     * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.
      */
     values(): IterableIterator<string>;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1287,8 +1287,8 @@ interface FormData {
     set(name: string, value: string | Blob, fileName?: string): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
@@ -1310,8 +1310,8 @@ interface Headers {
     set(name: string, value: string): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
 }
@@ -2687,8 +2687,8 @@ interface URLSearchParams {
     sort(): void;
     /**
      * Performs the specified action for each element in an list.
-     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
-     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
      */
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1285,6 +1285,11 @@ interface FormData {
     getAll(name: string): FormDataEntryValue[];
     has(name: string): boolean;
     set(name: string, value: string | Blob, fileName?: string): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: FormDataEntryValue, key: string, parent: FormData) => void, thisArg?: any): void;
 }
 
@@ -1303,6 +1308,11 @@ interface Headers {
     get(name: string): string | null;
     has(name: string): boolean;
     set(name: string, value: string): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: string, key: string, parent: Headers) => void, thisArg?: any): void;
 }
 
@@ -2675,6 +2685,11 @@ interface URLSearchParams {
      */
     set(name: string, value: string): void;
     sort(): void;
+    /**
+     * Performs the specified action for each element in an list.
+     * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.
+     * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.
+     */
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }
 

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -146,50 +146,6 @@
     },
     "interfaces": {
         "interface": {
-            "Headers": {
-                "iterator": {
-                    "comments": {
-                        "comment": {
-                            "entries": "/**\r\n * Returns an iterator allowing to go through all key/value pairs contained in this object.\r\n */",
-                            "keys": "/**\r\n * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.\r\n */",
-                            "values": "/**\r\n * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.\r\n */"
-                        }
-                    }
-                }
-            },
-            "FormData": {
-                "iterator": {
-                    "comments": {
-                        "comment": {
-                            "entries": "/**\r\n * Returns an array of key, value pairs for every entry in the list.\r\n */",
-                            "keys": "/**\r\n * Returns a list of keys in the list.\r\n */",
-                            "values": "/**\r\n * Returns a list of values in the list.\r\n */"
-                        }
-                    }
-                }
-            },
-            "NodeListOf<TNode extends Node>": {
-                "iterator": {
-                    "comments": {
-                        "comment": {
-                            "entries": "/**\r\n * Returns an array of key, value pairs for every entry in the list.\r\n */",
-                            "keys": "/**\r\n * Returns an list of keys in the list.\r\n */",
-                            "values": "/**\r\n * Returns an list of values in the list.\r\n */"
-                        }
-                    }
-                }
-            },
-            "NodeList": {
-                "iterator": {
-                    "comments": {
-                        "comment": {
-                            "entries": "/**\r\n * Returns an array of key, value pairs for every entry in the list.\r\n */",
-                            "keys": "/**\r\n * Returns an list of keys in the list.\r\n */",
-                            "values": "/**\r\n * Returns an list of values in the list.\r\n */"
-                        }
-                    }
-                }
-            },
             "HTMLTableElement": {
                 "properties": {
                     "property": {
@@ -1874,15 +1830,6 @@
                         }
                     },
                     "constructor": "/**\r\n * Constructor returning a URLSearchParams object.\r\n */"
-                },
-                "iterator": {
-                    "comments": {
-                        "comment": {
-                            "entries": "/**\r\n * Returns an array of key, value pairs for every entry in the search params.\r\n */",
-                            "keys": "/**\r\n * Returns a list of keys in the search params.\r\n */",
-                            "values": "/**\r\n * Returns a list of values in the search params.\r\n */"
-                        }
-                    }
                 }
             }
         }

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -169,13 +169,6 @@
                 }
             },
             "NodeListOf<TNode extends Node>": {
-                "methods": {
-                    "method": {
-                        "forEach": {
-                            "comment": "/**\r\n * Performs the specified action for each node in an list.\r\n * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.\r\n * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\r\n */"
-                        }
-                    }
-                },
                 "iterator": {
                     "comments": {
                         "comment": {
@@ -187,13 +180,6 @@
                 }
             },
             "NodeList": {
-                "methods": {
-                    "method": {
-                        "forEach": {
-                            "comment": "/**\r\n * Performs the specified action for each node in an list.\r\n * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.\r\n * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.\r\n */"
-                        }
-                    }
-                },
                 "iterator": {
                     "comments": {
                         "comment": {
@@ -838,9 +824,6 @@
                         },
                         "createNodeIterator": {
                             "comment": "/**\r\n * Creates a NodeIterator object that you can use to traverse filtered lists of nodes or elements in a document.\r\n * @param root The root element or node to start traversing on.\r\n * @param whatToShow The type of nodes or elements to appear in the node list\r\n * @param filter A custom NodeFilter function to use. For more information, see filter. Use null for no filter.\r\n * @param entityReferenceExpansion A flag that specifies whether entity reference nodes are expanded.\r\n */"
-                        },
-                        "getSelection": {
-                            "comment": "/**\r\n * Returns an object representing the current selection of the document that is loaded into the object displaying a webpage.\r\n */"
                         },
                         "getElementById": {
                             "comment": "/**\r\n * Returns a reference to the first object with the specified value of the ID or NAME attribute.\r\n * @param elementId String that specifies the ID value. Case-insensitive.\r\n */"

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -664,7 +664,8 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
     function emitSignatures(method: { signature: Browser.Signature[], "override-signatures"?: string[], "additional-signatures"?: string[] }, prefix: string, name: string, printLine: (s: string) => void) {
         if (method["override-signatures"]) {
             method["override-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
-        } else {
+        }
+        else {
             if (method["additional-signatures"]) {
                 method["additional-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
             }
@@ -699,6 +700,11 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
         const key = subtype.length > 1 ? subtype[0] :
             i.iterator.kind === "iterable" ? "number" : value;
         const name = i.name.replace(/ extends \w+/, "");
+        printer.printLine("/**");
+        printer.printLine(" * Performs the specified action for each element in an list.");
+        printer.printLine(" * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.");
+        printer.printLine(" * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.");
+        printer.printLine(" */");
         printer.printLine(`forEach(callbackfn: (value: ${value}, key: ${key}, parent: ${name}) => void, thisArg?: any): void;`);
     }
 
@@ -1145,7 +1151,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
             return `[${types.join(", ")}]`;
         }
 
-        function emitIterableDeclarationMethods(i: Browser.Interface, subtypes: string[]) {
+        function emitIterableDeclarationMethods(subtypes: string[]) {
             let [keyType, valueType] = subtypes;
             if (!valueType) {
                 valueType = keyType;
@@ -1155,22 +1161,19 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
             const methods = [{
                 name: 'entries',
                 definition: `IterableIterator<[${keyType}, ${valueType}]>`,
+                comment: "/**\r\n * Returns an iterator allowing to go through all key/value pairs contained in this object.\r\n */",
             }, {
                 name: 'keys',
                 definition: `IterableIterator<${keyType}>`,
+                comment: "/**\r\n * Returns an iterator allowing to go through all keys of the key/value pairs contained in this object.\r\n */",
             }, {
                 name: 'values',
                 definition: `IterableIterator<${valueType}>`,
+                comment: "/**\r\n * Returns an iterator allowing to go through all values of the key/value pairs contained in this object.\r\n */",
             }];
 
-            const comments = i.iterator
-                && i.iterator.comments
-                && i.iterator.comments.comment;
-
             methods.forEach((m) => {
-                if (comments && comments[m.name]) {
-                    comments[m.name].split('\n').forEach(printer.printLine);
-                }
+                m.comment.split('\n').forEach(printer.printLine);
                 printer.printLine(`${m.name}(): ${m.definition};`);
             });
         }
@@ -1199,7 +1202,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
                 printer.printLine(`[Symbol.iterator](): IterableIterator<${stringifySingleOrTupleTypes(subtypes)}>;`);
             }
             if (i.iterator && i.iterator.kind === "iterable") {
-                emitIterableDeclarationMethods(i, subtypes);
+                emitIterableDeclarationMethods(subtypes);
             }
             printer.decreaseIndent();
             printer.printLine("}");

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -702,8 +702,8 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
         const name = i.name.replace(/ extends \w+/, "");
         printer.printLine("/**");
         printer.printLine(" * Performs the specified action for each element in an list.");
-        printer.printLine(" * @param callbackfn  A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.");
-        printer.printLine(" * @param thisArg  An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.");
+        printer.printLine(" * @param callbackfn A function that accepts up to three arguments. forEach calls the callbackfn function one time for each element in the list.");
+        printer.printLine(" * @param thisArg An object to which the this keyword can refer in the callbackfn function. If thisArg is omitted, undefined is used as the this value.");
         printer.printLine(" */");
         printer.printLine(`forEach(callbackfn: (value: ${value}, key: ${key}, parent: ${name}) => void, thisArg?: any): void;`);
     }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -382,7 +382,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
         }
 
         return expectedMName === m.name &&
-            m.signature && m.signature.length === 1 &&
+            m.signature.length === 1 &&
             convertDomTypeToNullableTsType(m.signature[0]) === expectedMType &&
             m.signature[0].param && m.signature[0].param!.length === expectedParamType.length &&
             expectedParamType.every((pt, idx) => convertDomTypeToTsType(m.signature[0].param![idx]) === pt);
@@ -661,11 +661,10 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
         printLine(`${prefix || ""}${name || ""}(${paramsString}): ${returnType};`);
     }
 
-    function emitSignatures(method: { signature?: Browser.Signature[], "override-signatures"?: string[], "additional-signatures"?: string[] }, prefix: string, name: string, printLine: (s: string) => void) {
+    function emitSignatures(method: { signature: Browser.Signature[], "override-signatures"?: string[], "additional-signatures"?: string[] }, prefix: string, name: string, printLine: (s: string) => void) {
         if (method["override-signatures"]) {
             method["override-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
-        }
-        else if (method.signature) {
+        } else {
             if (method["additional-signatures"]) {
                 method["additional-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
             }
@@ -844,7 +843,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
 
     /// To decide if a given method is an indexer and should be emited
     function shouldEmitIndexerSignature(i: Browser.Interface, m: Browser.AnonymousMethod) {
-        if (m.getter && m.signature && m.signature[0].param && m.signature[0].param!.length === 1) {
+        if (m.getter && m.signature[0].param && m.signature[0].param!.length === 1) {
             // TypeScript array indexer can only be number or string
             // for string, it must return a more generic type then all
             // the other properties, following the Dictionary pattern
@@ -855,7 +854,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
                         return true;
                     }
                     const sig = m.signature[0];
-                    const mTypes = distinct(i.methods && map(i.methods.method, m => m.signature && m.signature.length && m.signature[0].type || "void").filter(t => t !== "void") || []);
+                    const mTypes = distinct(i.methods && map(i.methods.method, m => m.signature.length && m.signature[0].type || "void").filter(t => t !== "void") || []);
                     const amTypes = distinct(i["anonymous-methods"] && i["anonymous-methods"]!.method.map(m => m.signature[0].type).filter(t => t !== "void") || []); // |>  Array.distinct
                     const pTypes = distinct(i.properties && map(i.properties.property, m => m.type).filter(t => t !== "void") || []); // |>  Array.distinct
 
@@ -878,7 +877,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
                 .concat(i["anonymous-methods"] && i["anonymous-methods"]!.method || [])
                 .filter(m => shouldEmitIndexerSignature(i, m) && matchScope(emitScope, m))
                 .forEach(m => {
-                    const indexer = (m.signature && m.signature.length && m.signature[0].param && m.signature[0].param!.length) ? m.signature[0].param![0] : undefined;
+                    const indexer = (m.signature.length && m.signature[0].param && m.signature[0].param!.length) ? m.signature[0].param![0] : undefined;
                     if (indexer) {
                         printer.printLine(`[${indexer.name}: ${convertDomTypeToTsType(indexer)}]: ${convertDomTypeToTsType({
                             type: m.signature[0].type,

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -191,9 +191,6 @@ export interface Iterator {
     kind: "iterable" | "setlike" | "maplike";
     readonly: boolean;
     type: Typed[];
-    comments?: {
-        comment: Record<string, string>
-    };
 }
 
 export interface Enum {


### PR DESCRIPTION
Currently we have to manually add comments for `forEach()`, `values()`, etc. Instead, this PR automatically adds comments for those iteration methods.

A preceding work before fixing #443 and Microsoft/TypeScript#28198.