### PR TITLE
Small refactorings

### DIFF
--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -633,7 +633,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
         }
     }
 
-    function emitMethod(prefix: string, _i: Browser.Interface, m: Browser.Method, conflictedMembers: Set<string>) {
+    function emitMethod(prefix: string, m: Browser.Method, conflictedMembers: Set<string>) {
         function printLine(content: string) {
             if (m.name && conflictedMembers.has(m.name)) {
                 printer.printLineToStack(content);
@@ -682,7 +682,7 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
             mapToArray(i.methods.method)
                 .filter(m => matchScope(emitScope, m) && !(prefix !== "" && (m.name === "addEventListener" || m.name === "removeEventListener")))
                 .sort(compareName)
-                .forEach(m => emitMethod(prefix, i, m, conflictedMembers));
+                .forEach(m => emitMethod(prefix, m, conflictedMembers));
         }
 
         // The window interface inherited some methods from "Object",

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -573,21 +573,12 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
                     !!iNameToEhList[i.name].find(e => e.name === p.name));
     }
 
-    function emitProperty(prefix: string, i: Browser.Interface, emitScope: EmitScope, p: Browser.Property, conflictedMembers: Set<string>) {
-        function printLine(content: string) {
-            if (conflictedMembers.has(p.name)) {
-                printer.printLineToStack(content);
-            }
-            else {
-                printer.printLine(content);
-            }
-        }
-
-        emitComments(p, printLine);
+    function emitProperty(prefix: string, i: Browser.Interface, emitScope: EmitScope, p: Browser.Property) {
+        emitComments(p, printer.printLine);
 
         // Treat window.name specially because of https://github.com/Microsoft/TypeScript/issues/9850
         if (p.name === "name" && i.name === "Window" && emitScope === EmitScope.All) {
-            printLine("declare const name: never;");
+            printer.printLine("declare const name: never;");
         }
         else {
             let pType: string;
@@ -610,7 +601,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
             const requiredModifier = p.required === undefined || p.required === 1 ? "" : "?";
             pType = p.nullable ? makeNullable(pType) : pType;
             const readOnlyModifier = p["read-only"] === 1 && prefix === "" ? "readonly " : "";
-            printLine(`${prefix}${readOnlyModifier}${p.name}${requiredModifier}: ${pType};`);
+            printer.printLine(`${prefix}${readOnlyModifier}${p.name}${requiredModifier}: ${pType};`);
         }
     }
 
@@ -623,13 +614,13 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
         }
     }
 
-    function emitProperties(prefix: string, emitScope: EmitScope, i: Browser.Interface, conflictedMembers: Set<string>) {
+    function emitProperties(prefix: string, emitScope: EmitScope, i: Browser.Interface) {
         if (i.properties) {
             mapToArray(i.properties.property)
                 .filter(m => matchScope(emitScope, m))
                 .filter(p => !isCovariantEventHandler(i, p))
                 .sort(compareName)
-                .forEach(p => emitProperty(prefix, i, emitScope, p, conflictedMembers));
+                .forEach(p => emitProperty(prefix, i, emitScope, p));
         }
     }
 
@@ -708,7 +699,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
     /// Emit the properties and methods of a given interface
     function emitMembers(prefix: string, emitScope: EmitScope, i: Browser.Interface) {
         const conflictedMembers = extendConflictsBaseTypes[i.name] ? extendConflictsBaseTypes[i.name].memberNames : new Set();
-        emitProperties(prefix, emitScope, i, conflictedMembers);
+        emitProperties(prefix, emitScope, i);
         const methodPrefix = prefix.startsWith("declare var") ? "declare function " : "";
         emitMethods(methodPrefix, emitScope, i, conflictedMembers);
         if (emitScope === EmitScope.InstanceOnly) {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -120,7 +120,7 @@ function isEventHandler(p: Browser.Property) {
     return typeof p["event-handler"] === "string";
 }
 
-export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
+export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
     // Global print target
     const printer = createTextWriter("\n");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,13 +2,13 @@ import * as Browser from "./types";
 import * as fs from "fs";
 import * as path from "path";
 import { merge, resolveExposure, markAsDeprecated, mapToArray } from "./helpers";
-import { Flavor, emitWebIDl } from "./emitter";
+import { Flavor, emitWebIdl } from "./emitter";
 import { convert } from "./widlprocess";
 import { getExposedTypes } from "./expose";
 
 function emitDomWorker(webidl: Browser.WebIdl, tsWorkerOutput: string, forceKnownWorkerTypes: Set<string>) {
     const worker = getExposedTypes(webidl, "Worker", forceKnownWorkerTypes);
-    const result = emitWebIDl(worker, Flavor.Worker);
+    const result = emitWebIdl(worker, Flavor.Worker);
     fs.writeFileSync(tsWorkerOutput, result);
     return;
 }
@@ -16,13 +16,13 @@ function emitDomWorker(webidl: Browser.WebIdl, tsWorkerOutput: string, forceKnow
 function emitDomWeb(webidl: Browser.WebIdl, tsWebOutput: string, forceKnownWindowTypes: Set<string>) {
     const browser = getExposedTypes(webidl, "Window", forceKnownWindowTypes);
 
-    const result = emitWebIDl(browser, Flavor.Web);
+    const result = emitWebIdl(browser, Flavor.Web);
     fs.writeFileSync(tsWebOutput, result);
     return;
 }
 
 function emitES6DomIterators(webidl: Browser.WebIdl, tsWebIteratorsOutput: string) {
-    fs.writeFileSync(tsWebIteratorsOutput, emitWebIDl(webidl, Flavor.ES6Iterators));
+    fs.writeFileSync(tsWebIteratorsOutput, emitWebIdl(webidl, Flavor.ES6Iterators));
 }
 
 function emitDom() {


### PR DESCRIPTION
1. Fixes typo (`emitWebIDl` -> `emitWebIdl`).
2. Removes a redundant parameter from `emitMember`.
3. Removes confliction check in `emitProperty` as there is no conflicting property.