### PR TITLE
Allow URLs in Worker constructor

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16722,7 +16722,7 @@ interface Worker extends EventTarget, AbstractWorker {
 
 declare var Worker: {
     prototype: Worker;
-    new(stringUrl: string, options?: WorkerOptions): Worker;
+    new(stringUrl: string | URL, options?: WorkerOptions): Worker;
 };
 
 interface Worklet {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3879,7 +3879,7 @@ interface Worker extends EventTarget, AbstractWorker {
 
 declare var Worker: {
     prototype: Worker;
-    new(stringUrl: string, options?: WorkerOptions): Worker;
+    new(stringUrl: string | URL, options?: WorkerOptions): Worker;
 };
 
 interface WorkerGlobalScopeEventMap {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2328,7 +2328,7 @@
                 "override-exposed": "Window Worker",
                 "constructor": {
                     "override-signatures": [
-                        "new(stringUrl: string, options?: WorkerOptions): Worker"
+                        "new(stringUrl: string | URL, options?: WorkerOptions): Worker"
                     ]
                 },
                 "methods": {


### PR DESCRIPTION
Similar solution to https://github.com/Microsoft/TSJS-lib-generator/pull/332 to allow URLs to be passed into a Worker constructor.

Fixes https://github.com/Microsoft/TypeScript/issues/28397