### PR TITLE
Fix SVGElement.className

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4752,7 +4752,7 @@ interface ElementEventMap {
     "fullscreenerror": Event;
 }
 
-interface Element extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode, Slotable, Animatable {
+interface ElementBase extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode, Slotable, Animatable {
     readonly assignedSlot: HTMLSlotElement | null;
     readonly attributes: NamedNodeMap;
     /**
@@ -4760,11 +4760,6 @@ interface Element extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode,
      * set of whitespace-separated tokens through a DOMTokenList object.
      */
     readonly classList: DOMTokenList;
-    /**
-     * Returns the value of element's class content attribute. Can be set
-     * to change it.
-     */
-    className: string;
     readonly clientHeight: number;
     readonly clientLeft: number;
     readonly clientTop: number;
@@ -4906,6 +4901,14 @@ interface Element extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode,
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof ElementEventMap>(type: K, listener: (this: Element, ev: ElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
     removeEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | EventListenerOptions): void;
+}
+
+interface Element extends ElementBase {
+    /**
+     * Returns the value of element's class content attribute. Can be set
+     * to change it.
+     */
+    className: string;
 }
 
 declare var Element: {
@@ -6038,7 +6041,7 @@ declare var HTMLCollection: {
     new(): HTMLCollection;
 };
 
-interface HTMLCollectionOf<T extends Element> extends HTMLCollectionBase {
+interface HTMLCollectionOf<T extends Element> extends HTMLCollection {
     item(index: number): T | null;
     namedItem(name: string): T | null;
     [index: number]: T;
@@ -12354,9 +12357,8 @@ declare var SVGDescElement: {
 interface SVGElementEventMap extends ElementEventMap, GlobalEventHandlersEventMap, DocumentAndElementEventHandlersEventMap {
 }
 
-interface SVGElement extends Element, GlobalEventHandlers, DocumentAndElementEventHandlers, SVGElementInstance, HTMLOrSVGElement, ElementCSSInlineStyle {
-    /** @deprecated */
-    readonly className: any;
+interface SVGElement extends ElementBase, GlobalEventHandlers, DocumentAndElementEventHandlers, SVGElementInstance, HTMLOrSVGElement, ElementCSSInlineStyle {
+    readonly className: SVGAnimatedString;
     readonly ownerSVGElement: SVGSVGElement | null;
     readonly viewportElement: SVGElement | null;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -903,18 +903,6 @@
                     }
                 }
             },
-            "SVGElement": {
-                "name": "SVGElement",
-                "properties": {
-                    "property": {
-                        "className": {
-                            "deprecated": 1,
-                            "name": "className",
-                            "override-type": "any"
-                        }
-                    }
-                }
-            },
             "SVGSVGElement": {
                 "name": "SVGSVGElement",
                 "methods": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -22,6 +22,7 @@ enum EmitScope {
 const defaultEventType = "Event";
 const tsKeywords = new Set(["default", "delete", "continue"]);
 const extendConflictsBaseTypes: Record<string, { extendType: string[], memberNames: Set<string> }> = {
+    "Element": { extendType: ["SVGElement"], memberNames: new Set(["className"]) },
     "HTMLCollection": { extendType: ["HTMLFormControlsCollection"], memberNames: new Set(["namedItem"]) },
 };
 const eventTypeMap: Record<string, string> = {
@@ -822,7 +823,8 @@ export function emitWebIDl(webidl: Browser.WebIdl, flavor: Flavor) {
 
     function emitInterfaceDeclaration(i: Browser.Interface) {
         function processIName(iName: string) {
-            return extendConflictsBaseTypes[iName] ? `${iName}Base` : iName;
+            const conflict = extendConflictsBaseTypes[iName];
+            return conflict && (iName === i.name || conflict.extendType.includes(i.name)) ? `${iName}Base` : iName;
         }
 
         const processedIName = processIName(i.name);


### PR DESCRIPTION
Fixes Microsoft/TypeScript#19548

Also fixes `HTMLCollectionOf` incorrectly inherits from `HTMLCollectionBase` instead of `HTMLCollection`.