### PR TITLE
Override Node nextSibling to be type of ChildNode.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10384,7 +10384,7 @@ interface Node extends EventTarget {
     /**
      * Returns the next sibling.
      */
-    readonly nextSibling: Node | null;
+    readonly nextSibling: ChildNode | null;
     /**
      * Returns a string appropriate for the type of node, as
      * follows:

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -674,6 +674,9 @@
                             "read-only": 1,
                             "override-type": "string | null",
                             "deprecated": 1
+                        },
+                        "nextSibling": {
+                            "override-type": "ChildNode | null"
                         }
                     }
                 }


### PR DESCRIPTION
As discussed in https://github.com/Microsoft/TypeScript/issues/28551 a Node's `nextSibling` should have type of `ChildNode` so types can match when comparing or assigning elements.

I've noticed also `nextSibling` present in the interface `MutationRecord` [here](https://github.com/Microsoft/TSJS-lib-generator/blob/master/baselines/dom.generated.d.ts#L10225) and in the interface `TreeWalker` as a method [here](https://github.com/Microsoft/TSJS-lib-generator/blob/master/baselines/dom.generated.d.ts#L15023).

Not sure about those other two occurrences, but at least it seems consistent the change in `Node`. Let me know if you guys have any comment!

Cheers!