### PR TITLE
Mark window.event as deprecated

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16504,6 +16504,7 @@ interface Window extends EventTarget, WindowTimers, WindowSessionStorage, Window
     readonly devicePixelRatio: number;
     readonly doNotTrack: string;
     readonly document: Document;
+    /** @deprecated */
     readonly event: Event | undefined;
     /** @deprecated */
     readonly external: External;
@@ -17368,6 +17369,7 @@ declare var defaultStatus: string;
 declare var devicePixelRatio: number;
 declare var doNotTrack: string;
 declare var document: Document;
+/** @deprecated */
 declare var event: Event | undefined;
 /** @deprecated */
 declare var external: External;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -423,7 +423,8 @@
                     "property": {
                         "event": {
                             "name": "event",
-                            "override-type": "Event | undefined"
+                            "override-type": "Event | undefined",
+                            "deprecated": 1
                         },
                         "orientation": {
                             "name": "orientation",


### PR DESCRIPTION
[Per the spec](https://dom.spec.whatwg.org/#ref-for-dom-window-event):

>Web developers are strongly encouraged to instead rely on the `Event` object passed to event listeners, as that will result in more portable code. This attribute is not available in workers or worklets, and is inaccurate for events dispatched in shadow trees. 