### PR TITLE
Change AbortSignal's event type to Event

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1634,7 +1634,7 @@ declare var AbortController: {
 };
 
 interface AbortSignalEventMap {
-    "abort": ProgressEvent;
+    "abort": Event;
 }
 
 interface AbortSignal extends EventTarget {
@@ -1643,7 +1643,7 @@ interface AbortSignal extends EventTarget {
      * otherwise.
      */
     readonly aborted: boolean;
-    onabort: ((this: AbortSignal, ev: ProgressEvent) => any) | null;
+    onabort: ((this: AbortSignal, ev: Event) => any) | null;
     addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -480,7 +480,7 @@ declare var AbortController: {
 };
 
 interface AbortSignalEventMap {
-    "abort": ProgressEvent;
+    "abort": Event;
 }
 
 interface AbortSignal extends EventTarget {
@@ -489,7 +489,7 @@ interface AbortSignal extends EventTarget {
      * otherwise.
      */
     readonly aborted: boolean;
-    onabort: ((this: AbortSignal, ev: ProgressEvent) => any) | null;
+    onabort: ((this: AbortSignal, ev: Event) => any) | null;
     addEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof AbortSignalEventMap>(type: K, listener: (this: AbortSignal, ev: AbortSignalEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -198,7 +198,7 @@
                     "event": [
                         {
                             "name": "abort",
-                            "type": "ProgressEvent"
+                            "type": "Event"
                         }
                     ]
                 }


### PR DESCRIPTION
For some reason AbortSignal has event type of `ProgressEvent`, however I could not find anywhere, where it specifies that it must have `ProgressEvent` interface (might have been a copy-paste typo in https://github.com/Microsoft/TSJS-lib-generator/pull/523/commits/260bdbdcd279c2e89dc7d9be938ef03abcfa28c2). Therefore it it should have `Event` interface for `abort` event.

`ProgressEvent` could lead to errors: [proof (kinda)](http://jsfiddle.net/y5gacx3o/1/).