### PR TITLE
Fix ErrorEventHandler.error signature to `error?: any`.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -17045,7 +17045,7 @@ interface DecodeSuccessCallback {
 }
 
 interface ErrorEventHandler {
-    (event: Event | string, source?: string, fileno?: number, columnNumber?: number, error?: Error): void;
+    (event: Event | string, source?: string, fileno?: number, columnNumber?: number, error?: any): void;
 }
 
 interface EventHandlerNonNull {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -197,7 +197,7 @@
             "ErrorEventHandler": {
                 "name": "ErrorEventHandler",
                 "override-signatures": [
-                    "(event: Event | string, source?: string, fileno?: number, columnNumber?: number, error?: Error): void"
+                    "(event: Event | string, source?: string, fileno?: number, columnNumber?: number, error?: any): void"
                 ]
             },
             "DecodeErrorCallback": {


### PR DESCRIPTION
Fixes https://github.com/Microsoft/TypeScript/issues/28638