### PR TITLE
Make HTMLElement.nonce optional

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7652,7 +7652,7 @@ declare var HTMLOptionsCollection: {
 
 interface HTMLOrSVGElement {
     readonly dataset: DOMStringMap;
-    nonce: string;
+    nonce?: string;
     tabIndex: number;
     blur(): void;
     focus(options?: FocusOptions): void;

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -133,6 +133,16 @@
                     }
                 }
             },
+            "HTMLOrSVGElement": {
+              "name": "HTMLOrSVGElement",
+              "properties": {
+                "property": {
+                  "nonce": {
+                    "name": "nonce?"
+                  }
+                }
+              }
+            },
             "RandomSource": {
                 "name": "RandomSource",
                 "methods": {


### PR DESCRIPTION
Addresses https://github.com/Microsoft/TypeScript/issues/28452

I'm not entirely sure if my solution is the correct way to do it or if I should add some logic to emitter for creating optional properties.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/microsoft/tsjs-lib-generator/626)
<!-- Reviewable:end -->
