### PR TITLE
Remove inappropriate IDBKeyRange usages from lib.dom.d.ts.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -8691,12 +8691,12 @@ interface IDBCursor {
      * Returns the key of the cursor.
      * Throws a "InvalidStateError" DOMException if the cursor is advancing or is finished.
      */
-    readonly key: IDBValidKey | IDBKeyRange;
+    readonly key: IDBValidKey;
     /**
      * Returns the effective key of the cursor.
      * Throws a "InvalidStateError" DOMException if the cursor is advancing or is finished.
      */
-    readonly primaryKey: IDBValidKey | IDBKeyRange;
+    readonly primaryKey: IDBValidKey;
     /**
      * Returns the IDBObjectStore or IDBIndex the cursor was opened from.
      */
@@ -8710,12 +8710,12 @@ interface IDBCursor {
      * Advances the cursor to the next record in range matching or
      * after key.
      */
-    continue(key?: IDBValidKey | IDBKeyRange): void;
+    continue(key?: IDBValidKey): void;
     /**
      * Advances the cursor to the next record in range matching
      * or after key and primaryKey. Throws an "InvalidAccessError" DOMException if the source is not an index.
      */
-    continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void;
+    continuePrimaryKey(key: IDBValidKey, primaryKey: IDBValidKey): void;
     /**
      * Delete the record pointed at by the cursor with a new value.
      * If successful, request's result will be undefined.
@@ -8964,7 +8964,7 @@ interface IDBObjectStore {
      * Returns the associated transaction.
      */
     readonly transaction: IDBTransaction;
-    add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>;
+    add(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>;
     /**
      * Deletes all records in store.
      * If successful, request's result will
@@ -9037,7 +9037,7 @@ interface IDBObjectStore {
      * null if there were no matching records.
      */
     openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest<IDBCursor | null>;
-    put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>;
+    put(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>;
 }
 
 declare var IDBObjectStore: {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1394,12 +1394,12 @@ interface IDBCursor {
      * Returns the key of the cursor.
      * Throws a "InvalidStateError" DOMException if the cursor is advancing or is finished.
      */
-    readonly key: IDBValidKey | IDBKeyRange;
+    readonly key: IDBValidKey;
     /**
      * Returns the effective key of the cursor.
      * Throws a "InvalidStateError" DOMException if the cursor is advancing or is finished.
      */
-    readonly primaryKey: IDBValidKey | IDBKeyRange;
+    readonly primaryKey: IDBValidKey;
     /**
      * Returns the IDBObjectStore or IDBIndex the cursor was opened from.
      */
@@ -1413,12 +1413,12 @@ interface IDBCursor {
      * Advances the cursor to the next record in range matching or
      * after key.
      */
-    continue(key?: IDBValidKey | IDBKeyRange): void;
+    continue(key?: IDBValidKey): void;
     /**
      * Advances the cursor to the next record in range matching
      * or after key and primaryKey. Throws an "InvalidAccessError" DOMException if the source is not an index.
      */
-    continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void;
+    continuePrimaryKey(key: IDBValidKey, primaryKey: IDBValidKey): void;
     /**
      * Delete the record pointed at by the cursor with a new value.
      * If successful, request's result will be undefined.
@@ -1663,7 +1663,7 @@ interface IDBObjectStore {
      * Returns the associated transaction.
      */
     readonly transaction: IDBTransaction;
-    add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>;
+    add(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>;
     /**
      * Deletes all records in store.
      * If successful, request's result will
@@ -1736,7 +1736,7 @@ interface IDBObjectStore {
      * null if there were no matching records.
      */
     openKeyCursor(query?: IDBValidKey | IDBKeyRange, direction?: IDBCursorDirection): IDBRequest<IDBCursor | null>;
-    put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>;
+    put(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>;
 }
 
 declare var IDBObjectStore: {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -697,7 +697,7 @@
                         "add": {
                             "name": "add",
                             "override-signatures": [
-                                "add(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>"
+                                "add(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>"
                             ]
                         },
                         "clear": {
@@ -721,7 +721,7 @@
                         "put": {
                             "name": "put",
                             "override-signatures": [
-                                "put(value: any, key?: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey>"
+                                "put(value: any, key?: IDBValidKey): IDBRequest<IDBValidKey>"
                             ]
                         },
                         "get": {
@@ -1254,11 +1254,11 @@
                     "property": {
                         "key": {
                             "name": "key",
-                            "override-type": "IDBValidKey | IDBKeyRange"
+                            "override-type": "IDBValidKey"
                         },
                         "primaryKey": {
                             "name": "primaryKey",
-                            "override-type": "IDBValidKey | IDBKeyRange"
+                            "override-type": "IDBValidKey"
                         }
                     }
                 },
@@ -1267,13 +1267,13 @@
                         "continue": {
                             "name": "continue",
                             "override-signatures": [
-                                "continue(key?: IDBValidKey | IDBKeyRange): void"
+                                "continue(key?: IDBValidKey): void"
                             ]
                         },
                         "continuePrimaryKey": {
                             "name": "continuePrimaryKey",
                             "override-signatures": [
-                                "continuePrimaryKey(key: IDBValidKey | IDBKeyRange, primaryKey: IDBValidKey | IDBKeyRange): void"
+                                "continuePrimaryKey(key: IDBValidKey, primaryKey: IDBValidKey): void"
                             ]
                         },
                         "delete": {


### PR DESCRIPTION
I hit a compile error because IDBCursor.primaryKey was incorrectly typed as
`IDBValidKey | IDBKeyRange` instead of just `IDBValidKey`. I fixed it and
manually audited the rest of the instances of `IDBValidKey | IDBKeyRange` and
fixed them.  If there's a better way to fix these other than manual audit based
on my understanding of the IndexedDB API, let me know.

Fixes https://github.com/Microsoft/TypeScript/issues/29070
