### PR TITLE
Accept null in addition to string in createDataChannel

### DIFF
--- a/inputfiles/idl/WebRTC.widl
+++ b/inputfiles/idl/WebRTC.widl
@@ -486,7 +486,7 @@ dictionary RTCTrackEventInit : EventInit {
 
 partial interface RTCPeerConnection {
     readonly        attribute RTCSctpTransport? sctp;
-    RTCDataChannel createDataChannel (USVString label, optional RTCDataChannelInit dataChannelDict);
+    RTCDataChannel createDataChannel ((USVString or null) label, optional RTCDataChannelInit dataChannelDict);
                     attribute EventHandler      ondatachannel;
 };
 


### PR DESCRIPTION
`null` is treated as if an empty string was passed in.

https://developer.mozilla.org/en-US/docs/Web/API/RTCPeerConnection/createDataChannel#Parameters

This is my second attempt at Microsoft/TypeScript#29156.