### PR TITLE
Add CSS Images types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2603,6 +2603,8 @@ interface CSSStyleDeclaration {
     gridTemplateColumns: string | null;
     gridTemplateRows: string | null;
     height: string | null;
+    imageOrientation: string;
+    imageRendering: string;
     imeMode: string | null;
     justifyContent: string | null;
     justifyItems: string | null;
@@ -2685,8 +2687,8 @@ interface CSSStyleDeclaration {
     msWrapFlow: string;
     msWrapMargin: any;
     msWrapThrough: string;
-    objectFit: string | null;
-    objectPosition: string | null;
+    objectFit: string;
+    objectPosition: string;
     opacity: string | null;
     order: string | null;
     orphans: string | null;

--- a/inputfiles/idl/CSS Images.widl
+++ b/inputfiles/idl/CSS Images.widl
@@ -1,0 +1,6 @@
+partial interface CSSStyleDeclaration {
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString objectFit;
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString objectPosition;
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString imageOrientation;
+  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString imageRendering;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -13,6 +13,10 @@
         "title": "CSS Animations"
     },
     {
+        "url": "https://drafts.csswg.org/css-images-3/",
+        "title": "CSS Images"
+    },
+    {
         "url": "https://drafts.csswg.org/cssom-view/",
         "title": "CSSOM View"
     },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "scripts": {
     "build": "tsc --p ./tsconfig.json && node ./lib/index.js",
-    "fetch-idl": "npm run build && node ./lib/idlfetcher.js",
+    "fetch-idl": "tsc --p ./tsconfig.json && node ./lib/idlfetcher.js",
     "fetch-mdn": "npm run build && node ./lib/mdnfetcher.js",
     "fetch": "echo This could take a few minutes... && npm run fetch-idl && npm run fetch-mdn",
     "baseline-accept": "cpx \"generated\\*\" baselines\\",


### PR DESCRIPTION
Adding `style.imageOrientation` and `style.imageRendering`.

PS: b08845e is because the previous change prevents adding new types via `idlSources.json`, where any new field causes ENOENT when building before fetching.