### PR TITLE
Remove redundant added types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -392,6 +392,10 @@ interface EffectTiming {
     iterations?: number;
 }
 
+interface ElementCreationOptions {
+    is?: string;
+}
+
 interface ElementDefinitionOptions {
     extends?: string;
 }
@@ -2281,11 +2285,6 @@ declare var BroadcastChannel: {
     prototype: BroadcastChannel;
     new(name: string): BroadcastChannel;
 };
-
-interface BroadcastChannelEventMap {
-    message: MessageEvent;
-    messageerror: MessageEvent;
-}
 
 /** The ByteLengthQueuingStrategy interface of the the Streams API provides a built-in byte length queuing strategy that can be used when constructing streams. */
 interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
@@ -4988,10 +4987,6 @@ interface ElementContentEditable {
     contentEditable: string;
     inputMode: string;
     readonly isContentEditable: boolean;
-}
-
-interface ElementCreationOptions {
-    is?: string;
 }
 
 /** The ErrorEvent interface represents events providing information related to errors in scripts or in files. */
@@ -10784,15 +10779,6 @@ interface NodeListOf<TNode extends Node> extends NodeList {
      */
     forEach(callbackfn: (value: TNode, key: number, parent: NodeListOf<TNode>) => void, thisArg?: any): void;
     [index: number]: TNode;
-}
-
-interface NodeSelector {
-    querySelector<K extends keyof HTMLElementTagNameMap>(selectors: K): HTMLElementTagNameMap[K] | null;
-    querySelector<K extends keyof SVGElementTagNameMap>(selectors: K): SVGElementTagNameMap[K] | null;
-    querySelector<E extends Element = Element>(selectors: string): E | null;
-    querySelectorAll<K extends keyof HTMLElementTagNameMap>(selectors: K): NodeListOf<HTMLElementTagNameMap[K]>;
-    querySelectorAll<K extends keyof SVGElementTagNameMap>(selectors: K): NodeListOf<SVGElementTagNameMap[K]>;
-    querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
 }
 
 interface NonDocumentTypeChildNode {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -581,11 +581,6 @@ declare var BroadcastChannel: {
     new(name: string): BroadcastChannel;
 };
 
-interface BroadcastChannelEventMap {
-    message: MessageEvent;
-    messageerror: MessageEvent;
-}
-
 /** The ByteLengthQueuingStrategy interface of the the Streams API provides a built-in byte length queuing strategy that can be used when constructing streams. */
 interface ByteLengthQueuingStrategy extends QueuingStrategy<ArrayBufferView> {
     highWaterMark: number;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -193,30 +193,6 @@
                         }
                     }
                 }
-            },
-            "ParentNode": {
-                "name": "ParentNode",
-                "exposed": "Window",
-                "properties": {
-                    "property": {
-                        "firstElementChild": {
-                            "name": "firstElementChild",
-                            "read-only": 1,
-                            "override-type": "Element | null"
-                        },
-                        "lastElementChild": {
-                            "name": "lastElementChild",
-                            "read-only": 1,
-                            "override-type": "Element | null"
-                        },
-                        "childElementCount": {
-                            "name": "childElementCount",
-                            "read-only": 1,
-                            "override-type": "number"
-                        }
-                    }
-                },
-                "no-interface-object": "1"
             }
         }
     },
@@ -416,22 +392,6 @@
                         "name": "img"
                     }
                 ]
-            },
-            "BroadcastChannelEventMap": {
-                "name": "BroadcastChannelEventMap",
-                "properties": {
-                    "property": {
-                        "message": {
-                            "name": "message",
-                            "override-type": "MessageEvent"
-                        },
-                        "messageerror": {
-                            "name": "messageerror",
-                            "override-type": "MessageEvent"
-                        }
-                    }
-                },
-                "no-interface-object": "1"
             },
             "CSSStyleDeclaration": {
                 "name": "CSSStyleDeclaration",
@@ -1153,20 +1113,6 @@
                     }
                 }
             },
-            "ElementCreationOptions": {
-                "name": "ElementCreationOptions",
-                "exposed": "Window",
-                "properties": {
-                    "property": {
-                        "is": {
-                            "name": "is",
-                            "override-type": "string",
-                            "required": 0
-                        }
-                    }
-                },
-                "no-interface-object": "1"
-            },
             "HTMLMainElement": {
                 "name": "HTMLMainElement",
                 "extends": "HTMLElement",
@@ -1716,51 +1662,6 @@
                         "name": "dialog"
                     }
                 ]
-            },
-            "NodeSelector": {
-                "name": "NodeSelector",
-                "extends": "Object",
-                "no-interface-object": "1",
-                "methods": {
-                    "method": {
-                        "querySelectorAll": {
-                            "signature": [
-                                {
-                                    "param-min-required": 1,
-                                    "type": "NodeList",
-                                    "param": [
-                                        {
-                                            "name": "selectors",
-                                            "type": "DOMString",
-                                            "type-original": "DOMString"
-                                        }
-                                    ],
-                                    "type-original": "NodeList"
-                                }
-                            ],
-                            "name": "querySelectorAll"
-                        },
-                        "querySelector": {
-                            "signature": [
-                                {
-                                    "nullable": 1,
-                                    "param-min-required": 1,
-                                    "type": "Element",
-                                    "param": [
-                                        {
-                                            "name": "selectors",
-                                            "type": "DOMString",
-                                            "type-original": "DOMString"
-                                        }
-                                    ],
-                                    "type-original": "Element?"
-                                }
-                            ],
-                            "name": "querySelector"
-                        }
-                    }
-                },
-                "exposed": "Window"
             },
             "CSS": {
                 "name": "CSS",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2415,19 +2415,6 @@
                     ]
                 }
             },
-            "BroadcastChannel": {
-                "name": "BroadcastChannel",
-                "methods": {
-                    "method": {
-                        "postMessage": {
-                            "name": "postMessage",
-                            "override-signatures": [
-                                "postMessage(message: any): void"
-                            ]
-                        }
-                    }
-                }
-            },
             "MessagePort": {
                 "name": "MessagePort",
                 "methods": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -59,12 +59,8 @@ function createTextWriter(newLine: string) {
     /** print declarations conflicting with base interface to a side list to write them under a diffrent name later */
     let stack: { content: string, indent: number }[] = [];
 
-    const indentStrings: string[] = ["", "    "];
     function getIndentString(level: number) {
-        if (indentStrings[level] === undefined) {
-            indentStrings[level] = getIndentString(level - 1) + indentStrings[1];
-        }
-        return indentStrings[level];
+        return "    ".repeat(level);
     }
 
     function write(s: string) {
@@ -90,13 +86,12 @@ function createTextWriter(newLine: string) {
     reset();
 
     return {
-        reset: reset,
+        reset,
 
-        resetIndent() { indent = 0; },
         increaseIndent() { indent++; },
         decreaseIndent() { indent--; },
 
-        endLine: endLine,
+        endLine,
         print: write,
         printLine(c: string) { write(c); endLine(); },
 
@@ -830,7 +825,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
             .filter(i => i !== "Object")
             .map(processIName));
 
-        if (finalExtends && finalExtends.length) {
+        if (finalExtends.length) {
             printer.print(` extends ${finalExtends.join(", ")}`);
         }
         printer.print(" {");
@@ -916,7 +911,6 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
         printer.clearStack();
         emitInterfaceEventMap(i);
 
-        printer.resetIndent();
         emitInterfaceDeclaration(i);
         printer.increaseIndent();
 
@@ -950,7 +944,6 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
         // Because in the two cases the interface contains different things, it might be easier to
         // read to separate them into two functions.
         function emitStaticInterfaceWithNonStaticMembers() {
-            printer.resetIndent();
             emitInterfaceDeclaration(i);
             printer.increaseIndent();
 
@@ -971,7 +964,6 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
         }
 
         function emitPureStaticInterface() {
-            printer.resetIndent();
             emitInterfaceDeclaration(i);
             printer.increaseIndent();
 

--- a/src/idlfetcher.ts
+++ b/src/idlfetcher.ts
@@ -80,7 +80,7 @@ function extractCSSDefinitions(dom: DocumentFragment) {
         properties.map(property => `\n  [CEReactions] attribute [TreatNullAs=EmptyString] CSSOMString ${
             hyphenToCamelCase(property)
         };`).join("")
-    }\n};`
+    }\n};`;
 }
 
 function hyphenToCamelCase(name: string) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,7 +39,6 @@ function emitDom() {
     const tsWebIteratorsOutput = path.join(outputFolder, "dom.iterable.generated.d.ts");
     const tsWorkerOutput = path.join(outputFolder, "webworker.generated.d.ts");
 
-
     const overriddenItems = require(path.join(inputFolder, "overridingTypes.json"));
     const addedItems = require(path.join(inputFolder, "addedTypes.json"));
     const comments = require(path.join(inputFolder, "comments.json"));


### PR DESCRIPTION
1. `ElementCreationOptions` is already in IDL
1. `ParentNode` is already in IDL
1. `BroadcastChannelEventMap` is already defined elsewhere (we currently have two of them)
1. `NodeSelector` has been merged into `ParentNode` and is not used anymore

`ImageBitmapOptions` is covered by #571.