### PR TITLE
Remove document.createTouch()/createTouchList()

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4476,8 +4476,6 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
      * @param data String that specifies the nodeValue property of the text node.
      */
     createTextNode(data: string): Text;
-    createTouch(view: WindowProxy, target: EventTarget, identifier: number, pageX: number, pageY: number, screenX: number, screenY: number): Touch;
-    createTouchList(...touches: Touch[]): TouchList;
     /**
      * Creates a TreeWalker object that you can use to traverse filtered lists of nodes or elements in a document.
      * @param root The root element or node to start traversing on.

--- a/inputfiles/idl/Touch Events.widl
+++ b/inputfiles/idl/Touch Events.widl
@@ -68,10 +68,3 @@ partial interface GlobalEventHandlers {
                     attribute EventHandler ontouchmove;
                     attribute EventHandler ontouchcancel;
 };
-
-partial interface Document {
-  // Deprecated in this specification
-  Touch createTouch (WindowProxy view, EventTarget target, long identifier, double pageX, double pageY, double screenX, double screenY);
-  // Deprecated in this specification
-  TouchList createTouchList (Touch... touches);
-};


### PR DESCRIPTION
https://github.com/w3c/touch-events/pull/96 removed them back in Oct 2018 and now all Firefox, Edge and Chrome removed their support.

(MDN still says Firefox and Edge support them, so filed https://github.com/mdn/browser-compat-data/issues/3354)