### PR TITLE
Allow null for XPathResult.singleNodeValue

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -17411,7 +17411,7 @@ interface XPathResult {
     readonly invalidIteratorState: boolean;
     readonly numberValue: number;
     readonly resultType: number;
-    readonly singleNodeValue: Node;
+    readonly singleNodeValue: Node | null;
     readonly snapshotLength: number;
     readonly stringValue: string;
     iterateNext(): Node;


### PR DESCRIPTION
From the [specification](https://www.w3.org/TR/DOM-Level-3-XPath/xpath.html#XPathResult):

> The value of this single node result, which may be null.