### PR TITLE
Update Streams to spec version 46c3b89

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -12150,11 +12150,6 @@ interface ReadableStreamBYOBReader {
     releaseLock(): void;
 }
 
-declare var ReadableStreamBYOBReader: {
-    prototype: ReadableStreamBYOBReader;
-    new(stream: ReadableStream<Uint8Array>): ReadableStreamBYOBReader;
-};
-
 interface ReadableStreamBYOBRequest {
     readonly view: ArrayBufferView;
     respond(bytesWritten: number): void;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -910,6 +910,7 @@ interface PipeOptions {
     preventAbort?: boolean;
     preventCancel?: boolean;
     preventClose?: boolean;
+    signal?: AbortSignal;
 }
 
 interface PointerEventInit extends MouseEventInit {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -291,6 +291,7 @@ interface PipeOptions {
     preventAbort?: boolean;
     preventCancel?: boolean;
     preventClose?: boolean;
+    signal?: AbortSignal;
 }
 
 interface ProgressEventInit extends EventInit {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2446,11 +2446,6 @@ interface ReadableStreamBYOBReader {
     releaseLock(): void;
 }
 
-declare var ReadableStreamBYOBReader: {
-    prototype: ReadableStreamBYOBReader;
-    new(stream: ReadableStream<Uint8Array>): ReadableStreamBYOBReader;
-};
-
 interface ReadableStreamBYOBRequest {
     readonly view: ArrayBufferView;
     respond(bytesWritten: number): void;

--- a/inputfiles/idl/Streams.widl
+++ b/inputfiles/idl/Streams.widl
@@ -43,6 +43,7 @@ dictionary PipeOptions {
     boolean? preventClose;
     boolean? preventAbort;
     boolean? preventCancel;
+    AbortSignal? signal;
 };
 
 [Exposed=(Window,Worker)]

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2959,6 +2959,9 @@
                         },
                         "preventCancel": {
                             "nullable": 0
+                        },
+                        "signal": {
+                            "nullable": 0
                         }
                     }
                 }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2566,11 +2566,6 @@
                 "no-interface-object": "1"
             },
             "ReadableStreamBYOBReader": {
-                "constructor": {
-                    "override-signatures": [
-                        "new(stream: ReadableStream<Uint8Array>): ReadableStreamBYOBReader"
-                    ]
-                },
                 "methods": {
                     "method": {
                         "read": {
@@ -2579,7 +2574,8 @@
                             ]
                         }
                     }
-                }
+                },
+                "no-interface-object": 1
             },
             "ReadableStreamBYOBRequest": {
                 "no-interface-object": 1


### PR DESCRIPTION
This updates the type definitions for Streams to [spec version `46c3b89` of 7 November 2018](https://github.com/whatwg/streams/tree/46c3b89dd3aff28b2fc381dd1d397c12b4fb8a16) ([spec text](https://streams.spec.whatwg.org/commit-snapshots/46c3b89dd3aff28b2fc381dd1d397c12b4fb8a16/)).

* `PipeOptions` now takes an optional `AbortSignal`, to allow aborting an ongoing pipe operation started with `ReadableStream.pipeTo()` or `.pipeThrough()`

This also removes the (accidentally exposed) `ReadableStreamBYOBReader` constructor. [The spec defines](https://streams.spec.whatwg.org/commit-snapshots/46c3b89dd3aff28b2fc381dd1d397c12b4fb8a16/#globals) that this constructor should not be exposed.