### PR TITLE
Add Media Capture and Streams types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -236,7 +236,7 @@ interface ConstrainDoubleRange extends DoubleRange {
     ideal?: number;
 }
 
-interface ConstrainLongRange extends LongRange {
+interface ConstrainULongRange extends ULongRange {
     exact?: number;
     ideal?: number;
 }
@@ -606,11 +606,6 @@ interface KeyframeEffectOptions extends EffectTiming {
     iterationComposite?: IterationCompositeOperation;
 }
 
-interface LongRange {
-    max?: number;
-    min?: number;
-}
-
 interface MediaElementAudioSourceOptions {
     mediaElement: HTMLMediaElement;
 }
@@ -668,39 +663,45 @@ interface MediaStreamTrackAudioSourceOptions {
 }
 
 interface MediaStreamTrackEventInit extends EventInit {
-    track?: MediaStreamTrack | null;
+    track: MediaStreamTrack;
 }
 
 interface MediaTrackCapabilities {
-    aspectRatio?: number | DoubleRange;
+    aspectRatio?: DoubleRange;
+    autoGainControl?: boolean[];
+    channelCount?: ULongRange;
     deviceId?: string;
     echoCancellation?: boolean[];
-    facingMode?: string;
-    frameRate?: number | DoubleRange;
+    facingMode?: string[];
+    frameRate?: DoubleRange;
     groupId?: string;
-    height?: number | LongRange;
-    sampleRate?: number | LongRange;
-    sampleSize?: number | LongRange;
-    volume?: number | DoubleRange;
-    width?: number | LongRange;
+    height?: ULongRange;
+    latency?: DoubleRange;
+    noiseSuppression?: boolean[];
+    resizeMode?: string[];
+    sampleRate?: ULongRange;
+    sampleSize?: ULongRange;
+    volume?: DoubleRange;
+    width?: ULongRange;
 }
 
 interface MediaTrackConstraintSet {
-    aspectRatio?: number | ConstrainDoubleRange;
-    channelCount?: number | ConstrainLongRange;
-    deviceId?: string | string[] | ConstrainDOMStringParameters;
-    displaySurface?: string | string[] | ConstrainDOMStringParameters;
-    echoCancellation?: boolean | ConstrainBooleanParameters;
-    facingMode?: string | string[] | ConstrainDOMStringParameters;
-    frameRate?: number | ConstrainDoubleRange;
-    groupId?: string | string[] | ConstrainDOMStringParameters;
-    height?: number | ConstrainLongRange;
-    latency?: number | ConstrainDoubleRange;
-    logicalSurface?: boolean | ConstrainBooleanParameters;
-    sampleRate?: number | ConstrainLongRange;
-    sampleSize?: number | ConstrainLongRange;
-    volume?: number | ConstrainDoubleRange;
-    width?: number | ConstrainLongRange;
+    aspectRatio?: ConstrainDouble;
+    autoGainControl?: ConstrainBoolean;
+    channelCount?: ConstrainULong;
+    deviceId?: ConstrainDOMString;
+    echoCancellation?: ConstrainBoolean;
+    facingMode?: ConstrainDOMString;
+    frameRate?: ConstrainDouble;
+    groupId?: ConstrainDOMString;
+    height?: ConstrainULong;
+    latency?: ConstrainDouble;
+    noiseSuppression?: ConstrainBoolean;
+    resizeMode?: ConstrainDOMString;
+    sampleRate?: ConstrainULong;
+    sampleSize?: ConstrainULong;
+    volume?: ConstrainDouble;
+    width?: ConstrainULong;
 }
 
 interface MediaTrackConstraints extends MediaTrackConstraintSet {
@@ -709,12 +710,17 @@ interface MediaTrackConstraints extends MediaTrackConstraintSet {
 
 interface MediaTrackSettings {
     aspectRatio?: number;
+    autoGainControl?: boolean;
+    channelCount?: number;
     deviceId?: string;
     echoCancellation?: boolean;
     facingMode?: string;
     frameRate?: number;
     groupId?: string;
     height?: number;
+    latency?: number;
+    noiseSuppression?: boolean;
+    resizeMode?: string;
     sampleRate?: number;
     sampleSize?: number;
     volume?: number;
@@ -723,12 +729,17 @@ interface MediaTrackSettings {
 
 interface MediaTrackSupportedConstraints {
     aspectRatio?: boolean;
+    autoGainControl?: boolean;
+    channelCount?: boolean;
     deviceId?: boolean;
     echoCancellation?: boolean;
     facingMode?: boolean;
     frameRate?: boolean;
     groupId?: boolean;
     height?: boolean;
+    latency?: boolean;
+    noiseSuppression?: boolean;
+    resizeMode?: boolean;
     sampleRate?: boolean;
     sampleSize?: boolean;
     volume?: boolean;
@@ -1574,6 +1585,11 @@ interface TransitionEventInit extends EventInit {
 interface UIEventInit extends EventInit {
     detail?: number;
     view?: Window | null;
+}
+
+interface ULongRange {
+    max?: number;
+    min?: number;
 }
 
 interface UnderlyingByteSource {
@@ -9421,6 +9437,15 @@ interface InnerHTML {
     innerHTML: string;
 }
 
+interface InputDeviceInfo extends MediaDeviceInfo {
+    getCapabilities(): MediaTrackCapabilities;
+}
+
+declare var InputDeviceInfo: {
+    prototype: InputDeviceInfo;
+    new(): InputDeviceInfo;
+};
+
 /** provides a way to asynchronously observe changes in the intersection of a target element with an ancestor element or with a top-level document's viewport. */
 interface IntersectionObserver {
     readonly root: Element | null;
@@ -9853,6 +9878,7 @@ interface MediaDeviceInfo {
     readonly groupId: string;
     readonly kind: MediaDeviceKind;
     readonly label: string;
+    toJSON(): any;
 }
 
 declare var MediaDeviceInfo: {
@@ -9869,7 +9895,7 @@ interface MediaDevices extends EventTarget {
     ondevicechange: ((this: MediaDevices, ev: Event) => any) | null;
     enumerateDevices(): Promise<MediaDeviceInfo[]>;
     getSupportedConstraints(): MediaTrackSupportedConstraints;
-    getUserMedia(constraints: MediaStreamConstraints): Promise<MediaStream>;
+    getUserMedia(constraints?: MediaStreamConstraints): Promise<MediaStream>;
     addEventListener<K extends keyof MediaDevicesEventMap>(type: K, listener: (this: MediaDevices, ev: MediaDevicesEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof MediaDevicesEventMap>(type: K, listener: (this: MediaDevices, ev: MediaDevicesEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -10081,9 +10107,7 @@ declare var MediaSource: {
 };
 
 interface MediaStreamEventMap {
-    "active": Event;
     "addtrack": MediaStreamTrackEvent;
-    "inactive": Event;
     "removetrack": MediaStreamTrackEvent;
 }
 
@@ -10091,9 +10115,7 @@ interface MediaStreamEventMap {
 interface MediaStream extends EventTarget {
     readonly active: boolean;
     readonly id: string;
-    onactive: ((this: MediaStream, ev: Event) => any) | null;
     onaddtrack: ((this: MediaStream, ev: MediaStreamTrackEvent) => any) | null;
-    oninactive: ((this: MediaStream, ev: Event) => any) | null;
     onremovetrack: ((this: MediaStream, ev: MediaStreamTrackEvent) => any) | null;
     addTrack(track: MediaStreamTrack): void;
     clone(): MediaStream;
@@ -10102,7 +10124,6 @@ interface MediaStream extends EventTarget {
     getTracks(): MediaStreamTrack[];
     getVideoTracks(): MediaStreamTrack[];
     removeTrack(track: MediaStreamTrack): void;
-    stop(): void;
     addEventListener<K extends keyof MediaStreamEventMap>(type: K, listener: (this: MediaStream, ev: MediaStreamEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof MediaStreamEventMap>(type: K, listener: (this: MediaStream, ev: MediaStreamEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -10166,7 +10187,7 @@ declare var MediaStreamEvent: {
 };
 
 interface MediaStreamTrackEventMap {
-    "ended": MediaStreamErrorEvent;
+    "ended": Event;
     "isolationchange": Event;
     "mute": Event;
     "overconstrained": MediaStreamErrorEvent;
@@ -10181,15 +10202,13 @@ interface MediaStreamTrack extends EventTarget {
     readonly kind: string;
     readonly label: string;
     readonly muted: boolean;
-    onended: ((this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any) | null;
+    onended: ((this: MediaStreamTrack, ev: Event) => any) | null;
     onisolationchange: ((this: MediaStreamTrack, ev: Event) => any) | null;
     onmute: ((this: MediaStreamTrack, ev: Event) => any) | null;
     onoverconstrained: ((this: MediaStreamTrack, ev: MediaStreamErrorEvent) => any) | null;
     onunmute: ((this: MediaStreamTrack, ev: Event) => any) | null;
-    readonly readonly: boolean;
     readonly readyState: MediaStreamTrackState;
-    readonly remote: boolean;
-    applyConstraints(constraints: MediaTrackConstraints): Promise<void>;
+    applyConstraints(constraints?: MediaTrackConstraints): Promise<void>;
     clone(): MediaStreamTrack;
     getCapabilities(): MediaTrackCapabilities;
     getConstraints(): MediaTrackConstraints;
@@ -10221,7 +10240,7 @@ interface MediaStreamTrackEvent extends Event {
 
 declare var MediaStreamTrackEvent: {
     prototype: MediaStreamTrackEvent;
-    new(typeArg: string, eventInitDict?: MediaStreamTrackEventInit): MediaStreamTrackEvent;
+    new(type: string, eventInitDict: MediaStreamTrackEventInit): MediaStreamTrackEvent;
 };
 
 /** An interface of the Channel Messaging API allows us to create a new message channel and send data through it via its two MessagePort properties. */
@@ -10521,6 +10540,7 @@ interface Navigator extends NavigatorID, NavigatorOnLine, NavigatorContentUtils,
     gamepadInputEmulation: GamepadInputEmulationType;
     readonly geolocation: Geolocation;
     readonly maxTouchPoints: number;
+    readonly mediaDevices: MediaDevices;
     readonly mimeTypes: MimeTypeArray;
     readonly msManipulationViewsEnabled: boolean;
     readonly msMaxTouchPoints: number;
@@ -10531,6 +10551,7 @@ interface Navigator extends NavigatorID, NavigatorOnLine, NavigatorContentUtils,
     readonly serviceWorker: ServiceWorkerContainer;
     readonly webdriver: boolean;
     getGamepads(): (Gamepad | null)[];
+    getUserMedia(constraints: MediaStreamConstraints, successCallback: NavigatorUserMediaSuccessCallback, errorCallback: NavigatorUserMediaErrorCallback): void;
     getVRDisplays(): Promise<VRDisplay[]>;
     javaEnabled(): boolean;
     msLaunchUri(uri: string, successCallback?: MSLaunchUriCallback, noHandlerCallback?: MSLaunchUriCallback): void;
@@ -10960,6 +10981,15 @@ interface OscillatorNode extends AudioScheduledSourceNode {
 declare var OscillatorNode: {
     prototype: OscillatorNode;
     new(context: BaseAudioContext, options?: OscillatorOptions): OscillatorNode;
+};
+
+interface OverconstrainedError extends Error {
+    constraint: string;
+}
+
+declare var OverconstrainedError: {
+    prototype: OverconstrainedError;
+    new(): OverconstrainedError;
 };
 
 interface OverflowEvent extends UIEvent {
@@ -18444,6 +18474,10 @@ type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
 type OnErrorEventHandler = OnErrorEventHandlerNonNull | null;
 type OnBeforeUnloadEventHandler = OnBeforeUnloadEventHandlerNonNull | null;
 type TimerHandler = string | Function;
+type ConstrainULong = number | ConstrainULongRange;
+type ConstrainDouble = number | ConstrainDoubleRange;
+type ConstrainBoolean = boolean | ConstrainBooleanParameters;
+type ConstrainDOMString = string | string[] | ConstrainDOMStringParameters;
 type PerformanceEntryList = PerformanceEntry[];
 type VibratePattern = number | number[];
 type AlgorithmIdentifier = string | Algorithm;
@@ -18470,10 +18504,6 @@ type FormDataEntryValue = File | string;
 type InsertPosition = "beforebegin" | "afterbegin" | "beforeend" | "afterend";
 type IDBValidKey = number | string | Date | BufferSource | IDBArrayKey;
 type MutationRecordType = "attributes" | "characterData" | "childList";
-type ConstrainBoolean = boolean | ConstrainBooleanParameters;
-type ConstrainDOMString = string | string[] | ConstrainDOMStringParameters;
-type ConstrainDouble = number | ConstrainDoubleRange;
-type ConstrainLong = number | ConstrainLongRange;
 type IDBKeyPath = string;
 type Transferable = ArrayBuffer | MessagePort | ImageBitmap;
 type RTCIceGatherCandidate = RTCIceCandidateDictionary | RTCIceCandidateComplete;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1848,6 +1848,43 @@
                 "name": "SVGAnimateMotionElement",
                 "extends": "SVGAnimationElement",
                 "exposed": "Window"
+            },
+            "MediaStream": {
+                "events": {
+                    "event": [
+                        {
+                            "name": "addtrack",
+                            "type": "MediaStreamTrackEvent"
+                        },
+                        {
+                            "name": "removetrack",
+                            "type": "MediaStreamTrackEvent"
+                        }
+                    ]
+                }
+            },
+            "MediaStreamTrack": {
+                "events": {
+                    "event": [
+                        {
+                            "name": "overconstrained",
+                            "type": "MediaStreamErrorEvent"
+                        }
+                    ]
+                }
+            },
+            "OverconstrainedError": {
+                "name": "OverconstrainedError",
+                "extends": "Error",
+                "exposed": "Window",
+                "properties": {
+                    "property": {
+                        "constraint": {
+                            "name": "constraint",
+                            "type": "DOMString"
+                        }
+                    }
+                }
             }
         }
     },
@@ -1941,22 +1978,6 @@
             {
                 "new-type": "MutationRecordType",
                 "override-type": "\"attributes\" | \"characterData\" | \"childList\""
-            },
-            {
-                "new-type": "ConstrainBoolean",
-                "override-type": "boolean | ConstrainBooleanParameters"
-            },
-            {
-                "new-type": "ConstrainDOMString",
-                "override-type": "string | string[] | ConstrainDOMStringParameters"
-            },
-            {
-                "new-type": "ConstrainDouble",
-                "override-type": "number | ConstrainDoubleRange"
-            },
-            {
-                "new-type": "ConstrainLong",
-                "override-type": "number | ConstrainLongRange"
             },
             {
                 "new-type": "IDBKeyPath",

--- a/inputfiles/idl/Media Capture and Streams.widl
+++ b/inputfiles/idl/Media Capture and Streams.widl
@@ -1,0 +1,257 @@
+[Exposed=Window,
+ Constructor,
+ Constructor (MediaStream stream),
+ Constructor (sequence<MediaStreamTrack> tracks)]
+interface MediaStream : EventTarget {
+    readonly        attribute DOMString    id;
+    sequence<MediaStreamTrack> getAudioTracks ();
+    sequence<MediaStreamTrack> getVideoTracks ();
+    sequence<MediaStreamTrack> getTracks ();
+    MediaStreamTrack?          getTrackById (DOMString trackId);
+    void                       addTrack (MediaStreamTrack track);
+    void                       removeTrack (MediaStreamTrack track);
+    MediaStream                clone ();
+    readonly        attribute boolean      active;
+                    attribute EventHandler onaddtrack;
+                    attribute EventHandler onremovetrack;
+};
+
+[Exposed=Window]
+interface MediaStreamTrack : EventTarget {
+    readonly        attribute DOMString             kind;
+    readonly        attribute DOMString             id;
+    readonly        attribute DOMString             label;
+                    attribute boolean               enabled;
+    readonly        attribute boolean               muted;
+                    attribute EventHandler          onmute;
+                    attribute EventHandler          onunmute;
+    readonly        attribute MediaStreamTrackState readyState;
+                    attribute EventHandler          onended;
+    MediaStreamTrack       clone ();
+    void                   stop ();
+    MediaTrackCapabilities getCapabilities ();
+    MediaTrackConstraints  getConstraints ();
+    MediaTrackSettings     getSettings ();
+    Promise<void>          applyConstraints (optional MediaTrackConstraints constraints);
+                    attribute EventHandler          onoverconstrained;
+};
+
+enum MediaStreamTrackState {
+    "live",
+    "ended"
+};
+
+dictionary MediaTrackSupportedConstraints {
+             boolean width = true;
+             boolean height = true;
+             boolean aspectRatio = true;
+             boolean frameRate = true;
+             boolean facingMode = true;
+             boolean resizeMode = true;
+             boolean volume = true;
+             boolean sampleRate = true;
+             boolean sampleSize = true;
+             boolean echoCancellation = true;
+             boolean autoGainControl = true;
+             boolean noiseSuppression = true;
+             boolean latency = true;
+             boolean channelCount = true;
+             boolean deviceId = true;
+             boolean groupId = true;
+};
+
+dictionary MediaTrackCapabilities {
+             ULongRange           width;
+             ULongRange           height;
+             DoubleRange         aspectRatio;
+             DoubleRange         frameRate;
+             sequence<DOMString> facingMode;
+             sequence<DOMString> resizeMode;
+             DoubleRange         volume;
+             ULongRange           sampleRate;
+             ULongRange           sampleSize;
+             sequence<boolean>   echoCancellation;
+             sequence<boolean>   autoGainControl;
+             sequence<boolean>   noiseSuppression;
+             DoubleRange         latency;
+             ULongRange           channelCount;
+             DOMString           deviceId;
+             DOMString           groupId;
+};
+
+dictionary MediaTrackConstraints : MediaTrackConstraintSet {
+             sequence<MediaTrackConstraintSet> advanced;
+};
+
+dictionary MediaTrackConstraintSet {
+             ConstrainULong      width;
+             ConstrainULong      height;
+             ConstrainDouble    aspectRatio;
+             ConstrainDouble    frameRate;
+             ConstrainDOMString facingMode;
+             ConstrainDOMString resizeMode;
+             ConstrainDouble    volume;
+             ConstrainULong      sampleRate;
+             ConstrainULong      sampleSize;
+             ConstrainBoolean   echoCancellation;
+             ConstrainBoolean   autoGainControl;
+             ConstrainBoolean   noiseSuppression;
+             ConstrainDouble    latency;
+             ConstrainULong      channelCount;
+             ConstrainDOMString deviceId;
+             ConstrainDOMString groupId;
+};
+
+dictionary MediaTrackSettings {
+             long      width;
+             long      height;
+             double    aspectRatio;
+             double    frameRate;
+             DOMString facingMode;
+             DOMString resizeMode;
+             double    volume;
+             long      sampleRate;
+             long      sampleSize;
+             boolean   echoCancellation;
+             boolean   autoGainControl;
+             boolean   noiseSuppression;
+             double    latency;
+             long      channelCount;
+             DOMString deviceId;
+             DOMString groupId;
+};
+
+enum VideoFacingModeEnum {
+    "user",
+    "environment",
+    "left",
+    "right"
+};
+
+enum VideoResizeModeEnum {
+    "none",
+    "crop-and-scale"
+};
+
+[Exposed=Window,
+ Constructor (DOMString type, MediaStreamTrackEventInit eventInitDict)]
+interface MediaStreamTrackEvent : Event {
+    [SameObject]
+    readonly        attribute MediaStreamTrack track;
+};
+
+dictionary MediaStreamTrackEventInit : EventInit {
+    required MediaStreamTrack track;
+};
+
+[Exposed=Window,
+ Constructor (DOMString type, OverconstrainedErrorEventInit eventInitDict)]
+interface OverconstrainedErrorEvent : Event {
+    readonly        attribute OverconstrainedError? error;
+};
+
+dictionary OverconstrainedErrorEventInit : EventInit {
+             OverconstrainedError? error = null;
+};
+
+partial interface Navigator {
+    [SameObject, SecureContext]
+    readonly        attribute MediaDevices mediaDevices;
+};
+
+[Exposed=Window, SecureContext]
+interface MediaDevices : EventTarget {
+                    attribute EventHandler ondevicechange;
+    Promise<sequence<MediaDeviceInfo>> enumerateDevices ();
+};
+
+[Exposed=Window, SecureContext]
+interface MediaDeviceInfo {
+    readonly        attribute DOMString       deviceId;
+    readonly        attribute MediaDeviceKind kind;
+    readonly        attribute DOMString       label;
+    readonly        attribute DOMString       groupId;
+    [Default] object toJSON();
+};
+
+enum MediaDeviceKind {
+    "audioinput",
+    "audiooutput",
+    "videoinput"
+};
+
+[Exposed=Window] interface InputDeviceInfo : MediaDeviceInfo {
+    MediaTrackCapabilities getCapabilities ();
+};
+
+partial interface Navigator {
+    [SecureContext]
+    void getUserMedia (MediaStreamConstraints constraints, NavigatorUserMediaSuccessCallback successCallback, NavigatorUserMediaErrorCallback errorCallback);
+};
+
+partial interface MediaDevices {
+    MediaTrackSupportedConstraints getSupportedConstraints ();
+    Promise<MediaStream>           getUserMedia (optional MediaStreamConstraints constraints);
+};
+
+dictionary MediaStreamConstraints {
+             (boolean or MediaTrackConstraints) video = false;
+             (boolean or MediaTrackConstraints) audio = false;
+};
+
+callback NavigatorUserMediaSuccessCallback = void (MediaStream stream);
+
+callback NavigatorUserMediaErrorCallback = void (MediaStreamError error);
+
+typedef object MediaStreamError;
+
+dictionary DoubleRange {
+             double max;
+             double min;
+};
+
+dictionary ConstrainDoubleRange : DoubleRange {
+             double exact;
+             double ideal;
+};
+
+dictionary ULongRange {
+             [Clamp] unsigned long max;
+             [Clamp] unsigned long min;
+};
+
+dictionary ConstrainULongRange : ULongRange {
+             [Clamp] unsigned long exact;
+             [Clamp] unsigned long ideal;
+};
+
+dictionary ConstrainBooleanParameters {
+             boolean exact;
+             boolean ideal;
+};
+
+dictionary ConstrainDOMStringParameters {
+             (DOMString or sequence<DOMString>) exact;
+             (DOMString or sequence<DOMString>) ideal;
+};
+
+typedef ([Clamp] unsigned long or ConstrainULongRange) ConstrainULong;
+
+typedef (double or ConstrainDoubleRange) ConstrainDouble;
+
+typedef (boolean or ConstrainBooleanParameters) ConstrainBoolean;
+
+typedef (DOMString or sequence<DOMString> or ConstrainDOMStringParameters) ConstrainDOMString;
+
+dictionary Capabilities {
+};
+
+dictionary Settings {
+};
+
+dictionary ConstraintSet {
+};
+
+dictionary Constraints : ConstraintSet {
+             sequence<ConstraintSet> advanced;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -219,6 +219,10 @@
         "title": "Intersection Observer"
     },
     {
+        "url": "https://w3c.github.io/mediacapture-main/",
+        "title": "Media Capture and Streams"
+    },
+    {
         "url": "https://www.w3.org/TR/media-source/",
         "title": "Media Source Extensions"
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2861,25 +2861,6 @@
                     }
                 }
             },
-            "MediaTrackConstraintSet": {
-                "name": "MediaTrackConstraintSet",
-                "members": {
-                    "member": {
-                        "echoCancellation": {
-                            "name": "echoCancellation",
-                            "override-type": "boolean | ConstrainBooleanParameters"
-                        },
-                        "channelCount": {
-                            "name": "channelCount",
-                            "override-type": "number | ConstrainLongRange"
-                        },
-                        "latency": {
-                            "name": "latency",
-                            "override-type": "number | ConstrainDoubleRange"
-                        }
-                    }
-                }
-            },
             "BaseKeyframe": {
                 "name": "Keyframe",
                 "override-index-signatures": [

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -119,6 +119,7 @@
             "MSDSHEvent": null,
             "MSPortRange": null,
             "MSStreamReader": null,
+            "OverconstrainedErrorEvent": null,
             "Screen": {
                 "methods": {
                     "method": {


### PR DESCRIPTION
* `ConstrainLong`/`ConstrainLongRange`/`LongRange` are renamed to `*ULong*`
* `OverconstrainedError`/~~`OverconstrainedErrorEvent`~~ are added
* etc.

Removed `OverconstrainedErrorEvent` because no browser implements it (except Edge which implements it in its older name `MediaStreamErrorEvent`).