### PR TITLE
Remove deprecation of methods and add missing method in SVGSVGElement.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -14165,6 +14165,7 @@ interface SVGSVGElement extends SVGGraphicsElement, DocumentEvent, SVGFitToViewB
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
+    animationsPaused(): boolean;
     checkEnclosure(element: SVGElement, rect: SVGRect): boolean;
     checkIntersection(element: SVGElement, rect: SVGRect): boolean;
     createSVGAngle(): SVGAngle;
@@ -14179,18 +14180,14 @@ interface SVGSVGElement extends SVGGraphicsElement, DocumentEvent, SVGFitToViewB
     /** @deprecated */
     forceRedraw(): void;
     getComputedStyle(elt: Element, pseudoElt?: string | null): CSSStyleDeclaration;
-    /** @deprecated */
     getCurrentTime(): number;
     getElementById(elementId: string): Element;
     getEnclosureList(rect: SVGRect, referenceElement: SVGElement): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
     getIntersectionList(rect: SVGRect, referenceElement: SVGElement): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>;
-    /** @deprecated */
     pauseAnimations(): void;
-    /** @deprecated */
     setCurrentTime(seconds: number): void;
     /** @deprecated */
     suspendRedraw(maxWaitMilliseconds: number): number;
-    /** @deprecated */
     unpauseAnimations(): void;
     /** @deprecated */
     unsuspendRedraw(suspendHandleID: number): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -225,6 +225,19 @@
     },
     "interfaces": {
         "interface": {
+            "SVGSVGElement": {
+                "name": "SVGSVGElement",
+                "methods": {
+                    "method": {
+                        "animationsPaused": {
+                            "name": "animationsPaused",
+                            "override-signatures": [
+                                "animationsPaused(): boolean"
+                            ]
+                        }
+                    }
+                }
+            },
             "SVGFEDropShadowElement": {
                 "name": "SVGFEDropShadowElement",
                 "exposed": "Window",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -925,6 +925,22 @@
                             "override-signatures": [
                                 "getIntersectionList(rect: SVGRect, referenceElement: SVGElement): NodeListOf<SVGCircleElement | SVGEllipseElement | SVGImageElement | SVGLineElement | SVGPathElement | SVGPolygonElement | SVGPolylineElement | SVGRectElement | SVGTextElement | SVGUseElement>"
                             ]
+                        },
+                        "setCurrentTime": {
+                            "name": "setCurrentTime",
+                            "deprecated": 0
+                        },
+                        "pauseAnimations": {
+                            "name": "pauseAnimations",
+                            "deprecated": 0
+                        },
+                        "unpauseAnimations": {
+                            "name": "unpauseAnimations",
+                            "deprecated": 0
+                        },
+                        "getCurrentTime": {
+                            "name": "getCurrentTime",
+                            "deprecated": 0
                         }
                     }
                 }


### PR DESCRIPTION
As of https://github.com/Microsoft/TypeScript/issues/30368 this removes deprecation flag in `SVGSVGElement` for the properties `setCurrentTime`, `pauseAnimations`, `unpauseAnimations`, and `getCurrentTime`. It also adds the method `animationsPaused(): boolean`.

(closes https://github.com/Microsoft/TypeScript/issues/30368)