### PR TITLE
Revert "Narrow declared type of document.body to HTMLBodyElement | HT…

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4218,7 +4218,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
     /**
      * Specifies the beginning and end of the document body.
      */
-    body: HTMLBodyElement | HTMLFrameSetElement;
+    body: HTMLElement;
     /**
      * Returns document's encoding.
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -618,8 +618,7 @@
                             "nullable": false
                         },
                         "body": {
-                            "nullable": false,
-                            "override-type": "HTMLBodyElement | HTMLFrameSetElement"
+                            "nullable": false
                        }
                     }
                 }


### PR DESCRIPTION
…MLFrameSetElement"

This reverts commit 1f7b275407e9a92ea37674b13451d36cf449ba90.

That commit made `document.body` a union type, which in turns makes methods like `addEventListener` unions of overloaded signatures, which do not resolve correctly for the following example code, which I believe is very common:

```ts
document.body.addEventListener('click', (event) => {
    cx = event.pageX;
    cy = event.pageY;
});
```

With the union type, `event: Event`, which does not have `pageX` or `pageY` properties. After reverting this commit, `event: MouseEvent`, which does.