### PR TITLE
Add focusin/focusout to GlobalEventHandlers

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5567,6 +5567,8 @@ interface GlobalEventHandlersEventMap {
     "ended": Event;
     "error": ErrorEvent;
     "focus": FocusEvent;
+    "focusin": FocusEvent;
+    "focusout": FocusEvent;
     "gotpointercapture": PointerEvent;
     "input": Event;
     "invalid": Event;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5728,8 +5728,6 @@ interface GlobalEventHandlers {
      * @param ev The event.
      */
     onfocus: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
-    onfocusin: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
-    onfocusout: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
     ongotpointercapture: ((this: GlobalEventHandlers, ev: PointerEvent) => any) | null;
     oninput: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     oninvalid: ((this: GlobalEventHandlers, ev: Event) => any) | null;
@@ -18491,8 +18489,6 @@ declare var onerror: OnErrorEventHandler;
  * @param ev The event.
  */
 declare var onfocus: ((this: Window, ev: FocusEvent) => any) | null;
-declare var onfocusin: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
-declare var onfocusout: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
 declare var ongotpointercapture: ((this: Window, ev: PointerEvent) => any) | null;
 declare var oninput: ((this: Window, ev: Event) => any) | null;
 declare var oninvalid: ((this: Window, ev: Event) => any) | null;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5728,6 +5728,8 @@ interface GlobalEventHandlers {
      * @param ev The event.
      */
     onfocus: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
+    onfocusin: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
+    onfocusout: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
     ongotpointercapture: ((this: GlobalEventHandlers, ev: PointerEvent) => any) | null;
     oninput: ((this: GlobalEventHandlers, ev: Event) => any) | null;
     oninvalid: ((this: GlobalEventHandlers, ev: Event) => any) | null;
@@ -18489,6 +18491,8 @@ declare var onerror: OnErrorEventHandler;
  * @param ev The event.
  */
 declare var onfocus: ((this: Window, ev: FocusEvent) => any) | null;
+declare var onfocusin: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
+declare var onfocusout: ((this: GlobalEventHandlers, ev: FocusEvent) => any) | null;
 declare var ongotpointercapture: ((this: Window, ev: PointerEvent) => any) | null;
 declare var oninput: ((this: Window, ev: Event) => any) | null;
 declare var oninvalid: ((this: Window, ev: Event) => any) | null;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -72,6 +72,18 @@
                 }
             },
             "GlobalEventHandlers": {
+                "attributeless-events": {
+                    "event": [
+                        {
+                            "name": "focusin",
+                            "type": "FocusEvent"
+                        },
+                        {
+                            "name": "focusout",
+                            "type": "FocusEvent"
+                        }
+                    ]
+                },
                 "events": {
                     "event": [
                         {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -72,6 +72,19 @@
                 }
             },
             "GlobalEventHandlers": {
+                "name": "GlobalEventHandlers",
+                "properties": {
+                    "property": {
+                        "onfocusin": {
+                            "name": "onfocusin",
+                            "override-type": "((this: GlobalEventHandlers, ev: FocusEvent) => any) | null"
+                        },
+                        "onfocusout": {
+                            "name": "onfocusout",
+                            "override-type": "((this: GlobalEventHandlers, ev: FocusEvent) => any) | null"
+                        }
+                    }
+                },
                 "events": {
                     "event": [
                         {
@@ -109,6 +122,14 @@
                         {
                             "name": "drop",
                             "type": "DragEvent"
+                        },
+                        {
+                            "name": "focusin",
+                            "type": "FocusEvent"
+                        },
+                        {
+                            "name": "focusout",
+                            "type": "FocusEvent"
                         },
                         {
                             "name": "keydown",

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -72,19 +72,6 @@
                 }
             },
             "GlobalEventHandlers": {
-                "name": "GlobalEventHandlers",
-                "properties": {
-                    "property": {
-                        "onfocusin": {
-                            "name": "onfocusin",
-                            "override-type": "((this: GlobalEventHandlers, ev: FocusEvent) => any) | null"
-                        },
-                        "onfocusout": {
-                            "name": "onfocusout",
-                            "override-type": "((this: GlobalEventHandlers, ev: FocusEvent) => any) | null"
-                        }
-                    }
-                },
                 "events": {
                     "event": [
                         {
@@ -122,14 +109,6 @@
                         {
                             "name": "drop",
                             "type": "DragEvent"
-                        },
-                        {
-                            "name": "focusin",
-                            "type": "FocusEvent"
-                        },
-                        {
-                            "name": "focusout",
-                            "type": "FocusEvent"
                         },
                         {
                             "name": "keydown",

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -161,6 +161,9 @@ export interface Interface {
     events?: {
         event: Event[];
     }
+    "attributeless-events"?: {
+        event: Event[];
+    }
     properties?: {
         property: Record<string, Property>;
     }

--- a/src/widlprocess.ts
+++ b/src/widlprocess.ts
@@ -197,7 +197,7 @@ function convertOperation(operation: webidl2.OperationMemberType, inheritedExpos
         throw new Error("Unexpected anonymous operation");
     }
     return {
-        name: operation.name,
+        name: operation.name || undefined,
         signature: [{
             ...convertIdlType(operation.idlType),
             param: operation.arguments.map(convertArgument)


### PR DESCRIPTION
According to https://github.com/Microsoft/TypeScript/issues/30716 focusin/focusout are missing from `GlobalEventHandlersEventMap`.

I have added `onfocusin` and `onfocusout` to `GlobalEventHandlers` and the events `focusin` and `focusout`, which were supposed to be mapped, but they haven't shown up in `GlobalEventHandlersEventMap`, so I could use a small help!

@saschanaz, I've searched in the history and I noticed that in https://github.com/Microsoft/TSJS-lib-generator/pull/674 you've managed to add `deviceorientationabsolute` to `WindowEventMap`. How did you achieve that? I think I'm missing some detail here...

Also, I noticed that `onfocus` has a comment explaining its purpose, would it make sense to include comments also for `onfocusin` and `onfocusout`?

Fixes https://github.com/Microsoft/TypeScript/issues/30716