### PR TITLE
Add generic support to `Element.closest()`

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5018,7 +5018,7 @@ interface Element extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode,
      */
     closest<K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K] | null;
     closest<K extends keyof SVGElementTagNameMap>(selector: K): SVGElementTagNameMap[K] | null;
-    closest(selector: string): Element | null;
+    closest<E extends Element = Element>(selector: string): E | null;
     /**
      * Returns element's first attribute whose qualified name is qualifiedName, and null if there is no such attribute otherwise.
      */

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -722,7 +722,7 @@
                             "override-signatures": [
                                 "closest<K extends keyof HTMLElementTagNameMap>(selector: K): HTMLElementTagNameMap[K] | null",
                                 "closest<K extends keyof SVGElementTagNameMap>(selector: K): SVGElementTagNameMap[K] | null",
-                                "closest(selector: string): Element | null"
+                                "closest<E extends Element = Element>(selector: string): E | null"
                             ]
                         },
                         "insertAdjacentElement": {

--- a/src/widlprocess.ts
+++ b/src/widlprocess.ts
@@ -197,7 +197,7 @@ function convertOperation(operation: webidl2.OperationMemberType, inheritedExpos
         throw new Error("Unexpected anonymous operation");
     }
     return {
-        name: operation.name,
+        name: operation.name || undefined,
         signature: [{
             ...convertIdlType(operation.idlType),
             param: operation.arguments.map(convertArgument)


### PR DESCRIPTION
This now matches `querySelector`. Allows:

```js
element.closest<HTMLAnchorElement>('.lol')
// => HTMLAnchorElement
```