### PR TITLE
Restore FileReaderProgressEvent

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4535,6 +4535,7 @@ interface Document extends Node, NonElementParentNode, DocumentOrShadowRoot, Par
     createEvent(eventInterface: "ErrorEvent"): ErrorEvent;
     createEvent(eventInterface: "Event"): Event;
     createEvent(eventInterface: "Events"): Event;
+    createEvent(eventInterface: "FileReaderProgressEvent"): FileReaderProgressEvent;
     createEvent(eventInterface: "FocusEvent"): FocusEvent;
     createEvent(eventInterface: "FocusNavigationEvent"): FocusNavigationEvent;
     createEvent(eventInterface: "GamepadEvent"): GamepadEvent;
@@ -4786,6 +4787,7 @@ interface DocumentEvent {
     createEvent(eventInterface: "ErrorEvent"): ErrorEvent;
     createEvent(eventInterface: "Event"): Event;
     createEvent(eventInterface: "Events"): Event;
+    createEvent(eventInterface: "FileReaderProgressEvent"): FileReaderProgressEvent;
     createEvent(eventInterface: "FocusEvent"): FocusEvent;
     createEvent(eventInterface: "FocusNavigationEvent"): FocusNavigationEvent;
     createEvent(eventInterface: "GamepadEvent"): GamepadEvent;
@@ -5347,23 +5349,23 @@ declare var FileList: {
 };
 
 interface FileReaderEventMap {
-    "abort": ProgressEvent;
-    "error": ProgressEvent;
-    "load": ProgressEvent;
-    "loadend": ProgressEvent;
-    "loadstart": ProgressEvent;
-    "progress": ProgressEvent;
+    "abort": FileReaderProgressEvent;
+    "error": FileReaderProgressEvent;
+    "load": FileReaderProgressEvent;
+    "loadend": FileReaderProgressEvent;
+    "loadstart": FileReaderProgressEvent;
+    "progress": FileReaderProgressEvent;
 }
 
 /** Lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using File or Blob objects to specify the file or data to read. */
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent) => any) | null;
+    onabort: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onerror: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onload: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadend: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadstart: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onprogress: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
     readonly readyState: number;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
@@ -5387,6 +5389,10 @@ declare var FileReader: {
     readonly EMPTY: number;
     readonly LOADING: number;
 };
+
+interface FileReaderProgressEvent extends ProgressEvent {
+    readonly target: FileReader | null;
+}
 
 /** Focus-related events like focus, blur, focusin, or focusout. */
 interface FocusEvent extends UIEvent {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1525,23 +1525,23 @@ declare var FileList: {
 };
 
 interface FileReaderEventMap {
-    "abort": ProgressEvent;
-    "error": ProgressEvent;
-    "load": ProgressEvent;
-    "loadend": ProgressEvent;
-    "loadstart": ProgressEvent;
-    "progress": ProgressEvent;
+    "abort": FileReaderProgressEvent;
+    "error": FileReaderProgressEvent;
+    "load": FileReaderProgressEvent;
+    "loadend": FileReaderProgressEvent;
+    "loadstart": FileReaderProgressEvent;
+    "progress": FileReaderProgressEvent;
 }
 
 /** Lets web applications asynchronously read the contents of files (or raw data buffers) stored on the user's computer, using File or Blob objects to specify the file or data to read. */
 interface FileReader extends EventTarget {
     readonly error: DOMException | null;
-    onabort: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onerror: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onload: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadend: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onloadstart: ((this: FileReader, ev: ProgressEvent) => any) | null;
-    onprogress: ((this: FileReader, ev: ProgressEvent) => any) | null;
+    onabort: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onerror: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onload: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadend: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onloadstart: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
+    onprogress: ((this: FileReader, ev: FileReaderProgressEvent) => any) | null;
     readonly readyState: number;
     readonly result: string | ArrayBuffer | null;
     abort(): void;
@@ -1565,6 +1565,10 @@ declare var FileReader: {
     readonly EMPTY: number;
     readonly LOADING: number;
 };
+
+interface FileReaderProgressEvent extends ProgressEvent {
+    readonly target: FileReader | null;
+}
 
 /** Allows to read File or Blob objects in a synchronous way. */
 interface FileReaderSync {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -1964,6 +1964,21 @@
                         }
                     }
                 }
+            },
+            "FileReaderProgressEvent": {
+                "name": "FileReaderProgressEvent",
+                "extends": "ProgressEvent",
+                "no-interface-object": 1,
+                "properties": {
+                    "property": {
+                        "target": {
+                            "name": "target",
+                            "read-only": 1,
+                            "nullable": 1,
+                            "type": "FileReader"
+                        }
+                    }
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1862,27 +1862,27 @@
                     "event": [
                         {
                             "name": "loadstart",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         },
                         {
                             "name": "progress",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         },
                         {
                             "name": "load",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         },
                         {
                             "name": "abort",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         },
                         {
                             "name": "error",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         },
                         {
                             "name": "loadend",
-                            "type": "ProgressEvent"
+                            "type": "FileReaderProgressEvent"
                         }
                     ]
                 }

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -79,7 +79,6 @@
                     }
                 }
             },
-            "FileReaderProgressEvent": null,
             "HTMLAreasCollection": null,
             "HTMLBodyElement": {
                 "properties": {

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -153,7 +153,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
     /// Interface name to its related eventhandler name list map
     /// Note:
     /// In the xml file, each event handler has
-    /// 1. eventhanlder name: "onready", "onabort" etc.
+    /// 1. eventhandler name: "onready", "onabort" etc.
     /// 2. the event name that it handles: "ready", "SVGAbort" etc.
     /// And they don't just differ by an "on" prefix!
     const iNameToEhList = arrayToMap(allInterfaces, i => i.name, i =>

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -54,36 +54,36 @@ export function exposesTo(o: { exposed?: string }, target: string) {
     return o.exposed.includes(target);
 }
 
-export function merge<T>(src: T, target: T, shallow?: boolean): T {
-    if (typeof src !== "object" || typeof target !== "object") {
-        return target;
+export function merge<T>(target: T, src: T, shallow?: boolean): T {
+    if (typeof target !== "object" || typeof src !== "object") {
+        return src;
     }
-    for (const k in target) {
-        if (Object.getOwnPropertyDescriptor(target, k)) {
-            if (Object.getOwnPropertyDescriptor(src, k)) {
-                const srcProp = src[k];
+    for (const k in src) {
+        if (Object.getOwnPropertyDescriptor(src, k)) {
+            if (Object.getOwnPropertyDescriptor(target, k)) {
                 const targetProp = target[k];
-                if (Array.isArray(srcProp) && Array.isArray(targetProp)) {
-                    mergeNamedArrays(srcProp, targetProp);
+                const srcProp = src[k];
+                if (Array.isArray(targetProp) && Array.isArray(srcProp)) {
+                    mergeNamedArrays(targetProp, srcProp);
                 }
                 else {
-                    if (Array.isArray(srcProp) !== Array.isArray(targetProp)) {
-                        throw new Error("Mismatch on property: " + k + JSON.stringify(targetProp));
+                    if (Array.isArray(targetProp) !== Array.isArray(srcProp)) {
+                        throw new Error("Mismatch on property: " + k + JSON.stringify(srcProp));
                     }
-                    if (shallow && typeof (src[k] as any).name === "string" && typeof (target[k] as any).name === "string") {
-                        src[k] = target[k];
+                    if (shallow && typeof (target[k] as any).name === "string" && typeof (src[k] as any).name === "string") {
+                        target[k] = src[k];
                     }
                     else {
-                        src[k] = merge(src[k], target[k], shallow);
+                        target[k] = merge(target[k], src[k], shallow);
                     }
                 }
             }
             else {
-                src[k] = target[k];
+                target[k] = src[k];
             }
         }
     }
-    return src;
+    return target;
 }
 
 function mergeNamedArrays<T extends { name: string; "new-type": string; }>(srcProp: T[], targetProp: T[]) {


### PR DESCRIPTION
This type doesn't exist, but it did before about a year ago, and is useful until we parametrise ProgressEvent with subtype properties.

Also fixes variable names in `merge`, which had source and target backward, making for some confusing reading.

Fixes microsoft/Typescript#25510