### PR TITLE
fix inaccurate overrides for CSSOM

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -5214,8 +5214,8 @@ interface Element extends Node, ParentNode, NonDocumentTypeChildNode, ChildNode,
     getAttributeNames(): string[];
     getAttributeNode(name: string): Attr | null;
     getAttributeNodeNS(namespaceURI: string, localName: string): Attr | null;
-    getBoundingClientRect(): ClientRect | DOMRect;
-    getClientRects(): ClientRectList | DOMRectList;
+    getBoundingClientRect(): DOMRect;
+    getClientRects(): DOMRectList;
     /**
      * Returns a HTMLCollection of the elements in the object on which the method was invoked (a document or an element) that have all the classes given by classNames. The classNames argument is interpreted as a space-separated list of classes.
      */
@@ -9772,11 +9772,11 @@ declare var IntersectionObserver: {
 
 /** This Intersection Observer API interface describes the intersection between the target element and its root container at a specific moment of transition. */
 interface IntersectionObserverEntry {
-    readonly boundingClientRect: ClientRect | DOMRect;
+    readonly boundingClientRect: DOMRectReadOnly;
     readonly intersectionRatio: number;
-    readonly intersectionRect: ClientRect | DOMRect;
+    readonly intersectionRect: DOMRectReadOnly;
     readonly isIntersecting: boolean;
-    readonly rootBounds: ClientRect | DOMRect | null;
+    readonly rootBounds: DOMRectReadOnly | null;
     readonly target: Element;
     readonly time: number;
 }
@@ -12588,8 +12588,8 @@ interface Range extends AbstractRange {
     deleteContents(): void;
     detach(): void;
     extractContents(): DocumentFragment;
-    getBoundingClientRect(): ClientRect | DOMRect;
-    getClientRects(): ClientRectList | DOMRectList;
+    getBoundingClientRect(): DOMRect;
+    getClientRects(): DOMRectList;
     insertNode(node: Node): void;
     /**
      * Returns whether range intersects node.

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1180,18 +1180,6 @@
                 "name": "Element",
                 "methods": {
                     "method": {
-                        "getBoundingClientRect": {
-                            "name": "getBoundingClientRect",
-                            "override-signatures": [
-                                "getBoundingClientRect(): ClientRect | DOMRect"
-                            ]
-                        },
-                        "getClientRects": {
-                            "name": "getClientRects",
-                            "override-signatures": [
-                                "getClientRects(): ClientRectList | DOMRectList"
-                            ]
-                        },
                         "getAttributeNodeNS": {
                             "name": "getAttributeNodeNS",
                             "override-signatures": [
@@ -1714,47 +1702,6 @@
                             "type": "MessageEvent"
                         }
                     ]
-                }
-            },
-            "IntersectionObserverEntry": {
-                "name": "IntersectionObserverEntry",
-                "properties": {
-                    "property": {
-                        "boundingClientRect": {
-                            "name": "boundingClientRect",
-                            "read-only": 1,
-                            "override-type": "ClientRect | DOMRect"
-                        },
-                        "intersectionRect": {
-                            "name": "intersectionRect",
-                            "read-only": 1,
-                            "override-type": "ClientRect | DOMRect"
-                        },
-                        "rootBounds": {
-                            "name": "rootBounds",
-                            "read-only": 1,
-                            "override-type": "ClientRect | DOMRect"
-                        }
-                    }
-                }
-            },
-            "Range": {
-                "name": "Range",
-                "methods": {
-                    "method": {
-                        "getBoundingClientRect": {
-                            "name": "getBoundingClientRect",
-                            "override-signatures": [
-                                "getBoundingClientRect(): ClientRect | DOMRect"
-                            ]
-                        },
-                        "getClientRects": {
-                            "name": "getClientRects",
-                            "override-signatures": [
-                                "getClientRects(): ClientRectList | DOMRectList"
-                            ]
-                        }
-                    }
                 }
             },
             "WebSocket": {


### PR DESCRIPTION
This PR simply fixes a couple of inaccuracies that were introduced as overrides for CSSOM.

Should be fairly self-explanatory, but feel free to let me know if you have any questions/concerns.

Related:
- https://drafts.csswg.org/cssom-view/#dom-element-getclientrects
- https://drafts.csswg.org/cssom-view-1/#dom-element-getboundingclientrect