### PR TITLE
Update @types/node and typescript dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,9 +14,9 @@
       }
     },
     "@types/node": {
-      "version": "9.4.6",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.4.6.tgz",
-      "integrity": "sha512-CTUtLb6WqCCgp6P59QintjHWqzf4VL1uPA27bipLAPxFqrtK1gEYllePzTICGqQ8rYsCbpnsNypXjjDzGAAjEQ=="
+      "version": "9.6.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+      "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA=="
     },
     "@types/node-fetch": {
       "version": "1.6.7",
@@ -1689,6 +1689,11 @@
       "requires": {
         "prelude-ls": "~1.1.2"
       }
+    },
+    "typescript": {
+      "version": "3.6.0-dev.20190710",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.0-dev.20190710.tgz",
+      "integrity": "sha512-NmMwd8fW9wrYB/U5zQbKam91hiiQts/awYdNi1rP/0IlvPhRhUuo5HkGcFnQe7Q/uZFtPH8uZwxRDLDYi29DyQ=="
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@types/jsdom": "^11.0.4",
-    "@types/node": "^9.4.6",
+    "@types/node": "^9.6.49",
     "@types/node-fetch": "^1.6.7",
     "@types/webidl2": "^10.2.1",
     "cpx": "^1.5.0",


### PR DESCRIPTION
The new version of @types/node avoids the new generator types introduced recently in typescript@next.