### PR TITLE
Override Body.json() to allow passing a generic type

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2513,7 +2513,7 @@ interface Body {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<FormData>;
-    json(): Promise<any>;
+    json<T extends any>(): Promise<T>;
     text(): Promise<string>;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -636,7 +636,7 @@ interface Body {
     arrayBuffer(): Promise<ArrayBuffer>;
     blob(): Promise<Blob>;
     formData(): Promise<FormData>;
-    json(): Promise<any>;
+    json<T extends any>(): Promise<T>;
     text(): Promise<string>;
 }
 

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -204,6 +204,16 @@
                             "override-type": "ReadableStream<Uint8Array> | null"
                         }
                     }
+                },
+                "methods": {
+                    "method": {
+                        "json": {
+                            "name": "json",
+                            "override-signatures": [
+                                "json<T extends any>(): Promise<T>"
+                            ]
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
I'm primarily making this PR as I've made a similar PR to DefinitelyTyped's typings for node-fetch where the reviewer feedback was to stick to what TypeScript has defined in `lib.dom.ts`, you can see that PR [here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/36868). That said, let's get into details.

Right now `<Body>.json()` returns `Promise<any>` which means that if we want typed JSON we'd either have to do `const someData: someType = someBody.json()` or `const someData = someBody.json() as someType`. Both of these ways include a certain form of type casting the `someData`. By allowing `<Body>.json()` to accept a generic type however the structure of `const someData = someBody.json<someType>()` would **additionally** become possible. Since `T` extends `any`, omitting the generic will still result in `Promise<any>` and therefore it should not affect any existing code.

Taking example code from the aforementioned PR to DefinitelyTyped node-fetch typings here are practical code examples, utilising the node-fetch package:

**Before**:
```ts
(async function() {
    try {
      // Fetch Reddit comments for a user
      const response = await fetch(`https://www.reddit.com/user/favna/comments.json?after=''&limit=100`);
      const json: RedditResponse<'comments'> = await response.json();
      // or
      const json2 = await response.json() as RedditResponse<'comments'>;
      //  Do something with the JSON
    } catch (err) {
        throw new Error(err);
    }
})();
```

**After**:
```ts
(async function() {
    try {
      // Fetch Reddit comments for a user
      const response = await fetch(`https://www.reddit.com/user/favna/comments.json?after=''&limit=100`);
      const json = await response.json<RedditResponse<'comments'>>();
      //  Do something with the JSON
    } catch (err) {
        throw new Error(err);
    }
})();
```

Signed-off-by: Jeroen Claassens <support@favware.tech>