### PR TITLE
Allow requesting permission for device orientation

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4381,6 +4381,7 @@ interface DeviceMotionEvent extends Event {
 declare var DeviceMotionEvent: {
     prototype: DeviceMotionEvent;
     new(type: string, eventInitDict?: DeviceMotionEventInit): DeviceMotionEvent;
+    requestPermission(): Promise<PermissionState>;
 };
 
 interface DeviceMotionEventAcceleration {
@@ -4406,6 +4407,7 @@ interface DeviceOrientationEvent extends Event {
 declare var DeviceOrientationEvent: {
     prototype: DeviceOrientationEvent;
     new(type: string, eventInitDict?: DeviceOrientationEventInit): DeviceOrientationEvent;
+    requestPermission(): Promise<PermissionState>;
 };
 
 /** Provides information about the rate at which the device is rotating around all three axes. */

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -89,20 +89,6 @@
                     }
                 }
             },
-            "DeviceMotionEvent": {
-                "methods": {
-                    "method": {
-                        "requestPermission": null
-                    }
-                }
-            },
-            "DeviceOrientationEvent": {
-                "methods": {
-                    "method": {
-                        "requestPermission": null
-                    }
-                }
-            },
             "FederatedCredential": null,
             "HTMLAreasCollection": null,
             "HTMLBodyElement": {


### PR DESCRIPTION
iOS Safari 13 Beta 6 has shipped with permission API for DeviceMotionEvent and DeviceOrientationEvent, see:
https://developer.apple.com/documentation/safari_release_notes/safari_13_beta_6_release_notes#3314664