### PR TITLE
Improve Streams

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15665,6 +15665,8 @@ interface TextDecoderCommon {
 }
 
 interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
+    readonly readable: ReadableStream<string>;
+    readonly writable: WritableStream<BufferSource>;
 }
 
 declare var TextDecoderStream: {
@@ -15697,6 +15699,8 @@ interface TextEncoderCommon {
 }
 
 interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
+    readonly readable: ReadableStream<Uint8Array>;
+    readonly writable: WritableStream<string>;
 }
 
 declare var TextEncoderStream: {

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -1496,6 +1496,16 @@ interface RTCTransportStats extends RTCStats {
     selectedCandidatePairId?: string;
 }
 
+interface ReadableStreamReadDoneResult<T> {
+    done: true;
+    value?: T;
+}
+
+interface ReadableStreamReadValueResult<T> {
+    done: false;
+    value: T;
+}
+
 interface RegistrationOptions {
     scope?: string;
     type?: WorkerType;
@@ -12707,11 +12717,6 @@ interface ReadableStreamDefaultReader<R = any> {
     releaseLock(): void;
 }
 
-interface ReadableStreamReadResult<T> {
-    done: boolean;
-    value: T;
-}
-
 interface ReadableStreamReader<R = any> {
     cancel(): Promise<void>;
     read(): Promise<ReadableStreamReadResult<R>>;
@@ -19967,6 +19972,7 @@ type ConstrainDouble = number | ConstrainDoubleRange;
 type ConstrainBoolean = boolean | ConstrainBooleanParameters;
 type ConstrainDOMString = string | string[] | ConstrainDOMStringParameters;
 type PerformanceEntryList = PerformanceEntry[];
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
 type VibratePattern = number | number[];
 type COSEAlgorithmIdentifier = number;
 type AuthenticatorSelectionList = AAGUID[];

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -371,6 +371,16 @@ interface QueuingStrategy<T = any> {
     size?: QueuingStrategySizeCallback<T>;
 }
 
+interface ReadableStreamReadDoneResult<T> {
+    done: true;
+    value?: T;
+}
+
+interface ReadableStreamReadValueResult<T> {
+    done: false;
+    value: T;
+}
+
 interface RegistrationOptions {
     scope?: string;
     type?: WorkerType;
@@ -2758,11 +2768,6 @@ interface ReadableStreamDefaultReader<R = any> {
     cancel(reason?: any): Promise<void>;
     read(): Promise<ReadableStreamReadResult<R>>;
     releaseLock(): void;
-}
-
-interface ReadableStreamReadResult<T> {
-    done: boolean;
-    value: T;
 }
 
 interface ReadableStreamReader<R = any> {
@@ -5804,6 +5809,7 @@ type ImageBitmapSource = CanvasImageSource | Blob | ImageData;
 type TimerHandler = string | Function;
 type PerformanceEntryList = PerformanceEntry[];
 type PushMessageDataInit = BufferSource | string;
+type ReadableStreamReadResult<T> = ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>;
 type VibratePattern = number | number[];
 type AlgorithmIdentifier = string | Algorithm;
 type HashAlgorithmIdentifier = AlgorithmIdentifier;

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3088,6 +3088,8 @@ interface TextDecoderCommon {
 }
 
 interface TextDecoderStream extends GenericTransformStream, TextDecoderCommon {
+    readonly readable: ReadableStream<string>;
+    readonly writable: WritableStream<BufferSource>;
 }
 
 declare var TextDecoderStream: {
@@ -3120,6 +3122,8 @@ interface TextEncoderCommon {
 }
 
 interface TextEncoderStream extends GenericTransformStream, TextEncoderCommon {
+    readonly readable: ReadableStream<Uint8Array>;
+    readonly writable: WritableStream<string>;
 }
 
 declare var TextEncoderStream: {

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2190,6 +2190,38 @@
                         }
                     }
                 }
+            },
+            "TextDecoderStream": {
+                "properties": {
+                    "property": {
+                        "readable": {
+                            "name": "readable",
+                            "read-only": 1,
+                            "override-type": "ReadableStream<string>"
+                        },
+                        "writable": {
+                            "name": "writable",
+                            "read-only": 1,
+                            "override-type": "WritableStream<BufferSource>"
+                        }
+                    }
+                }
+            },
+            "TextEncoderStream": {
+                "properties": {
+                    "property": {
+                        "readable": {
+                            "name": "readable",
+                            "read-only": 1,
+                            "override-type": "ReadableStream<Uint8Array>"
+                        },
+                        "writable": {
+                            "name": "writable",
+                            "read-only": 1,
+                            "override-type": "WritableStream<string>"
+                        }
+                    }
+                }
             }
         }
     },

--- a/inputfiles/idl/Streams.widl
+++ b/inputfiles/idl/Streams.widl
@@ -46,12 +46,18 @@ dictionary PipeOptions {
     AbortSignal? signal;
 };
 
-[Exposed=(Window,Worker),
- NoInterfaceObject]
-interface ReadableStreamReadResult {
-    attribute boolean done;
-    attribute any value;
+dictionary ReadableStreamReadValueResult {
+    required boolean done;
+    required any value;
 };
+
+dictionary ReadableStreamReadDoneResult {
+    required boolean done;
+    any value;
+};
+
+[Exposed=(Window,Worker)]
+typedef (ReadableStreamReadValueResult or ReadableStreamReadDoneResult) ReadableStreamReadResult;
 
 [Exposed=(Window,Worker),
  NoInterfaceObject]

--- a/inputfiles/idl/Streams.widl
+++ b/inputfiles/idl/Streams.widl
@@ -46,14 +46,15 @@ dictionary PipeOptions {
     AbortSignal? signal;
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableStreamReadResult {
     attribute boolean done;
     attribute any value;
 };
 
-[Constructor(ReadableStream stream),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableStreamDefaultReader {
     readonly attribute Promise<void> closed;
 
@@ -62,8 +63,8 @@ interface ReadableStreamDefaultReader {
     void releaseLock();
 };
 
-[Constructor(ReadableStream stream),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableStreamBYOBReader {
     readonly attribute Promise<void> closed;
 
@@ -72,7 +73,8 @@ interface ReadableStreamBYOBReader {
     void releaseLock();
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableStreamDefaultController {
     readonly attribute unrestricted double? desiredSize;
 
@@ -81,7 +83,8 @@ interface ReadableStreamDefaultController {
     void error(optional any error);
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableByteStreamController {
     readonly attribute ReadableStreamBYOBRequest byobRequest;
     readonly attribute unrestricted double? desiredSize;
@@ -91,7 +94,8 @@ interface ReadableByteStreamController {
     void error(optional any error);
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface ReadableStreamBYOBRequest {
     readonly attribute ArrayBufferView view;
 
@@ -121,8 +125,8 @@ dictionary UnderlyingSink {
     any type;
 };
 
-[Constructor(ReadableStream stream),
- Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface WritableStreamDefaultWriter {
     readonly attribute Promise<void> closed;
     readonly attribute unrestricted double? desiredSize;
@@ -134,7 +138,8 @@ interface WritableStreamDefaultWriter {
     Promise<void> write(any chunk);
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface WritableStreamDefaultController {
     void error(optional any error);
 };
@@ -158,7 +163,8 @@ dictionary Transformer {
     any writableType;
 };
 
-[Exposed=(Window,Worker)]
+[Exposed=(Window,Worker),
+ NoInterfaceObject]
 interface TransformStreamDefaultController {
     readonly attribute unrestricted double? desiredSize;
 

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2492,20 +2492,6 @@
                     }
                 }
             },
-            "ReadableStreamReadResult": {
-                "type-parameters": [
-                    {
-                        "name": "T"
-                    }
-                ],
-                "properties": {
-                    "property": {
-                        "value": {
-                            "override-type": "T"
-                        }
-                    }
-                }
-            },
             "ReadableStreamBYOBReader": {
                 "methods": {
                     "method": {
@@ -2961,6 +2947,40 @@
                     }
                 }
             },
+            "ReadableStreamReadDoneResult": {
+                "type-parameters": [
+                    {
+                        "name": "T"
+                    }
+                ],
+                "members": {
+                    "member": {
+                        "done": {
+                            "override-type": "true"
+                        },
+                        "value": {
+                            "override-type": "T"
+                        }
+                    }
+                }
+            },
+            "ReadableStreamReadValueResult": {
+                "type-parameters": [
+                    {
+                        "name": "T"
+                    }
+                ],
+                "members": {
+                    "member": {
+                        "done": {
+                            "override-type": "false"
+                        },
+                        "value": {
+                            "override-type": "T"
+                        }
+                    }
+                }
+            },
             "UnderlyingByteSource": {
                 "members": {
                     "member": {
@@ -3128,6 +3148,15 @@
             {
                 "override-type": "Blob | BufferSource | FormData | URLSearchParams | ReadableStream<Uint8Array> | string",
                 "new-type": "BodyInit"
+            },
+            {
+                "override-type": "ReadableStreamReadValueResult<T> | ReadableStreamReadDoneResult<T>",
+                "new-type": "ReadableStreamReadResult",
+                "type-parameters": [
+                    {
+                        "name": "T"
+                    }
+                ]
             }
         ]
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2504,8 +2504,7 @@
                             "override-type": "T"
                         }
                     }
-                },
-                "no-interface-object": "1"
+                }
             },
             "ReadableStreamBYOBReader": {
                 "methods": {
@@ -2516,11 +2515,7 @@
                             ]
                         }
                     }
-                },
-                "no-interface-object": 1
-            },
-            "ReadableStreamBYOBRequest": {
-                "no-interface-object": 1
+                }
             },
             "ReadableStreamDefaultReader": {
                 "type-parameters": [
@@ -2537,8 +2532,7 @@
                             ]
                         }
                     }
-                },
-                "no-interface-object": 1
+                }
             },
             "ReadableByteStreamController": {
                 "properties": {
@@ -2547,8 +2541,7 @@
                             "override-type": "ReadableStreamBYOBRequest | undefined"
                         }
                     }
-                },
-                "no-interface-object": 1
+                }
             },
             "ReadableStreamDefaultController": {
                 "type-parameters": [
@@ -2565,8 +2558,7 @@
                             ]
                         }
                     }
-                },
-                "no-interface-object": 1
+                }
             },
             "WritableStream": {
                 "override-exposed": "Window Worker",
@@ -2591,10 +2583,6 @@
                     }
                 }
             },
-            "WritableStreamDefaultController": {
-                "override-exposed": "Window Worker",
-                "no-interface-object": 1
-            },
             "WritableStreamDefaultWriter": {
                 "override-exposed": "Window Worker",
                 "type-parameters": [
@@ -2611,8 +2599,7 @@
                             ]
                         }
                     }
-                },
-                "no-interface-object": 1
+                }
             },
             "TransformStream": {
                 "type-parameters": [
@@ -2657,8 +2644,7 @@
                             ]
                         }
                     }
-                },
-                "no-interface-object": 1
+                }
             },
             "ByteLengthQueuingStrategy": {
                 "override-exposed": "Window Worker",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2561,7 +2561,6 @@
                 }
             },
             "WritableStream": {
-                "override-exposed": "Window Worker",
                 "constructor": {
                     "override-signatures": [
                         "new<W = any>(underlyingSink?: UnderlyingSink<W>, strategy?: QueuingStrategy<W>): WritableStream<W>"
@@ -2584,7 +2583,6 @@
                 }
             },
             "WritableStreamDefaultWriter": {
-                "override-exposed": "Window Worker",
                 "type-parameters": [
                     {
                         "name": "W",
@@ -2629,7 +2627,6 @@
                 }
             },
             "TransformStreamDefaultController": {
-                "override-exposed": "Window Worker",
                 "type-parameters": [
                     {
                         "name": "O",
@@ -2647,7 +2644,6 @@
                 }
             },
             "ByteLengthQueuingStrategy": {
-                "override-exposed": "Window Worker",
                 "extends": "QueuingStrategy<ArrayBufferView>",
                 "constructor": {
                     "override-signatures": [
@@ -2656,7 +2652,6 @@
                 }
             },
             "CountQueuingStrategy": {
-                "override-exposed": "Window Worker",
                 "constructor": {
                     "override-signatures": [
                         "new(options: { highWaterMark: number }): CountQueuingStrategy"

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -405,7 +405,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
             expectedParamType.every((pt, idx) => convertDomTypeToTsType(m.signature[0].param![idx]) === pt);
     }
 
-    function getNameWithTypeParameter(i: Browser.Interface | Browser.Dictionary | Browser.CallbackFunction, name: string) {
+    function getNameWithTypeParameter(i: Browser.Interface | Browser.Dictionary | Browser.CallbackFunction | Browser.TypeDef, name: string) {
         function typeParameterWithDefault(type: Browser.TypeParameter) {
             return type.name
                 + (type.extends ? ` extends ${type.extends}` : "")
@@ -1094,7 +1094,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
 
     function emitTypeDef(typeDef: Browser.TypeDef) {
         emitComments(typeDef, printer.printLine);
-        printer.printLine(`type ${typeDef["new-type"]} = ${convertDomTypeToTsType(typeDef)};`);
+        printer.printLine(`type ${getNameWithTypeParameter(typeDef, typeDef["new-type"])} = ${convertDomTypeToTsType(typeDef)};`);
     }
 
     function emitTypeDefs() {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -224,6 +224,7 @@ export interface TypeDef extends Typed {
     "new-type": string;
     deprecated?: 1;
     "legacy-namespace"?: string;
+    "type-parameters"?: TypeParameter[];
 }
 
 export interface Dictionary {


### PR DESCRIPTION
This PR improves the type definitions for [Streams](https://streams.spec.whatwg.org/):
* Align `ReadableStreamReadResult` with the new [`IteratorResult`](https://github.com/microsoft/TypeScript/blob/v3.6.2/src/lib/es2015.iterable.d.ts#L21) definition from TypeScript 3.6. It is now equivalent to `IteratorResult<T, T | undefined>`, but since the DOM types cannot depend on `es2015.iterable`, I needed to add my own `typedef` with a union type. Fortunately, TypeScript will recognize these as equivalent thanks to its structural type system. 😄 Since this is a *generic* type alias, I have updated the emitter to support type parameters for `typedef`s.
* Add chunk types to `TextEncoderStream` and `TextDecoderStream` from [the Encoding standard](https://encoding.spec.whatwg.org/). Their `readable` and `writable` properties were defined as just `ReadableStream` and `WritableStream`, so they had the default chunk type `any`. Now, we use the precise chunk types from the spec.

I've also done some cleanup on how the Streams types are defined:
* Use `[NoInterfaceObject]` in (manually authored) WebIDL, instead of adding `"no-interface-object"` to the overrides.
* Remove unnecessary `"override-exposed"` where the exposure was already correctly defined in the WebIDL.