### PR TITLE
Random fixes for HTML media and EME

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10316,7 +10316,7 @@ declare var MediaKeyMessageEvent: {
 
 interface MediaKeySessionEventMap {
     "keystatuseschange": Event;
-    "message": MessageEvent;
+    "message": MediaKeyMessageEvent;
 }
 
 /** This EncryptedMediaExtensions API interface represents a context for message exchange with a content decryption module (CDM). */
@@ -10325,7 +10325,7 @@ interface MediaKeySession extends EventTarget {
     readonly expiration: number;
     readonly keyStatuses: MediaKeyStatusMap;
     onkeystatuseschange: ((this: MediaKeySession, ev: Event) => any) | null;
-    onmessage: ((this: MediaKeySession, ev: MessageEvent) => any) | null;
+    onmessage: ((this: MediaKeySession, ev: MediaKeyMessageEvent) => any) | null;
     readonly sessionId: string;
     close(): Promise<void>;
     generateRequest(initDataType: string, initData: BufferSource): Promise<void>;

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4491,7 +4491,7 @@ interface DocumentEventMap extends GlobalEventHandlersEventMap, DocumentAndEleme
     "fullscreenerror": Event;
     "pointerlockchange": Event;
     "pointerlockerror": Event;
-    "readystatechange": ProgressEvent<Document>;
+    "readystatechange": Event;
     "visibilitychange": Event;
 }
 
@@ -4650,7 +4650,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * Fires when the state of the object has changed.
      * @param ev The event
      */
-    onreadystatechange: ((this: Document, ev: ProgressEvent<Document>) => any) | null;
+    onreadystatechange: ((this: Document, ev: Event) => any) | null;
     onvisibilitychange: ((this: Document, ev: Event) => any) | null;
     /**
      * Returns document's origin.

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7646,7 +7646,7 @@ declare var HTMLMarqueeElement: {
 
 interface HTMLMediaElementEventMap extends HTMLElementEventMap {
     "encrypted": MediaEncryptedEvent;
-    "msneedkey": Event;
+    "msneedkey": MSMediaKeyNeededEvent;
     "waitingforkey": Event;
 }
 
@@ -7743,7 +7743,7 @@ interface HTMLMediaElement extends HTMLElement {
     readonly networkState: number;
     onencrypted: ((this: HTMLMediaElement, ev: MediaEncryptedEvent) => any) | null;
     /** @deprecated */
-    onmsneedkey: ((this: HTMLMediaElement, ev: Event) => any) | null;
+    onmsneedkey: ((this: HTMLMediaElement, ev: MSMediaKeyNeededEvent) => any) | null;
     onwaitingforkey: ((this: HTMLMediaElement, ev: Event) => any) | null;
     /**
      * Gets a flag that specifies whether playback is paused.

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10346,7 +10346,7 @@ declare var MediaKeySession: {
 /** This EncryptedMediaExtensions API interface is a read-only map of media key statuses by key IDs. */
 interface MediaKeyStatusMap {
     readonly size: number;
-    get(keyId: BufferSource): any;
+    get(keyId: BufferSource): MediaKeyStatus | undefined;
     has(keyId: BufferSource): boolean;
     forEach(callbackfn: (value: MediaKeyStatus, key: BufferSource, parent: MediaKeyStatusMap) => void, thisArg?: any): void;
 }

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -15885,11 +15885,15 @@ declare var TextTrackCueList: {
 
 interface TextTrackListEventMap {
     "addtrack": TrackEvent;
+    "change": Event;
+    "removetrack": TrackEvent;
 }
 
 interface TextTrackList extends EventTarget {
     readonly length: number;
     onaddtrack: ((this: TextTrackList, ev: TrackEvent) => any) | null;
+    onchange: ((this: TextTrackList, ev: Event) => any) | null;
+    onremovetrack: ((this: TextTrackList, ev: TrackEvent) => any) | null;
     item(index: number): TextTrack;
     addEventListener<K extends keyof TextTrackListEventMap>(type: K, listener: (this: TextTrackList, ev: TextTrackListEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2226,6 +2226,36 @@
                         }
                     }
                 }
+            },
+            "TextTrackList": {
+                "properties": {
+                    "property": {
+                        "onchange": {
+                            "name": "onchange",
+                            "type": "EventHandler",
+                            "event-handler": "change",
+                            "nullable": 1
+                        },
+                        "onremovetrack": {
+                            "name": "onremovetrack",
+                            "type": "EventHandler",
+                            "event-handler": "removetrack",
+                            "nullable": 1
+                        }
+                    }
+                },
+                "events": {
+                    "event": [
+                        {
+                            "name": "change",
+                            "type": "Event"
+                        },
+                        {
+                            "name": "removetrack",
+                            "type": "TrackEvent"
+                        }
+                    ]
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2761,6 +2761,16 @@
                         }
                     }
                 }
+            },
+            "MediaKeySession": {
+                "events": {
+                    "event": [
+                        {
+                            "name": "message",
+                            "type": "MediaKeyMessageEvent"
+                        }
+                    ]
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -642,6 +642,14 @@
                             "nullable": false
                        }
                     }
+                },
+                "events": {
+                    "event": [
+                        {
+                            "name": "readystatechange",
+                            "type": "Event"
+                        }
+                    ]
                 }
             },
             "Node": {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2787,6 +2787,18 @@
                         }
                     ]
                 }
+            },
+            "MediaKeyStatusMap": {
+                "methods": {
+                    "method": {
+                        "get": {
+                            "name": "get",
+                            "override-signatures": [
+                                "get(keyId: BufferSource): MediaKeyStatus | undefined"
+                            ]
+                        }
+                    }
+                }
             }
         }
     },

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1260,6 +1260,14 @@
                             ]
                         }
                     }
+                },
+                "events": {
+                    "event": [
+                        {
+                            "name": "msneedkey",
+                            "type": "MSMediaKeyNeededEvent"
+                        }
+                    ]
                 }
             },
             "DataTransferItemList": {


### PR DESCRIPTION
At work, we found a couple of incorrect and/or missing types while dealing with [HTML media elements](https://html.spec.whatwg.org/multipage/media.html) and [EME](https://www.w3.org/TR/encrypted-media/). This PR fixes some of these types.