### PR TITLE
Make ImageData(Uint8ClampedArray)'s 3rd param optional

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -9762,7 +9762,7 @@ interface ImageData {
 declare var ImageData: {
     prototype: ImageData;
     new(width: number, height: number): ImageData;
-    new(array: Uint8ClampedArray, width: number, height: number): ImageData;
+    new(array: Uint8ClampedArray, width: number, height?: number): ImageData;
 };
 
 interface InnerHTML {

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -2202,7 +2202,7 @@ interface ImageData {
 declare var ImageData: {
     prototype: ImageData;
     new(width: number, height: number): ImageData;
-    new(array: Uint8ClampedArray, width: number, height: number): ImageData;
+    new(array: Uint8ClampedArray, width: number, height?: number): ImageData;
 };
 
 /** This Channel Messaging API interface allows us to create a new message channel and send data through it via its two MessagePort properties. */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1066,7 +1066,7 @@
                 "constructor": {
                     "override-signatures": [
                         "new(width: number, height: number): ImageData",
-                        "new(array: Uint8ClampedArray, width: number, height: number): ImageData"
+                        "new(array: Uint8ClampedArray, width: number, height?: number): ImageData"
                     ]
                 }
             },


### PR DESCRIPTION
It can be inferred from the first two.

Fixes Microsoft/Typescript#33266