### PR TITLE
Document URLSearchParams.toString()

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -16103,6 +16103,9 @@ interface URLSearchParams {
      */
     set(name: string, value: string): void;
     sort(): void;
+    /**
+     * Returns a string containing a query string suitable for use in a URL. Does not include the question mark.
+     */
     toString(): string;
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -3256,6 +3256,9 @@ interface URLSearchParams {
      */
     set(name: string, value: string): void;
     sort(): void;
+    /**
+     * Returns a string containing a query string suitable for use in a URL. Does not include the question mark.
+     */
     toString(): string;
     forEach(callbackfn: (value: string, key: string, parent: URLSearchParams) => void, thisArg?: any): void;
 }

--- a/inputfiles/comments.json
+++ b/inputfiles/comments.json
@@ -1855,6 +1855,9 @@
                         },
                         "set": {
                             "comment": "/**\n * Sets the value associated to a given search parameter to the given value. If there were several values, delete the others.\n */"
+                        },
+                        "toString": {
+                            "comment": "/**\n * Returns a string containing a query string suitable for use in a URL. Does not include the question mark.\n */"
                         }
                     },
                     "constructor": "/**\n * Constructor returning a URLSearchParams object.\n */"


### PR DESCRIPTION
Description taken from https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams/toString.