### PR TITLE
customElement.define's 2nd parameter is a constructor

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19255,7 +19255,7 @@ interface BlobCallback {
 }
 
 interface CustomElementConstructor {
-    (): HTMLElement;
+    new (): HTMLElement;
 }
 
 interface DecodeErrorCallback {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -311,6 +311,11 @@
                 "override-signatures": [
                     "(chunk: I, controller: TransformStreamDefaultController<O>): void | PromiseLike<void>"
                 ]
+            },
+            "CustomElementConstructor": {
+                "override-signatures": [
+                    "new (): HTMLElement"
+                ]
             }
         }
     },


### PR DESCRIPTION
Previously it was a call signature, but this is not correct. I'm not sure if `HTML - Custom Elements.widl` is wrong or whether our interpretation of it is wrong. A call signature does not match actual usage or the semantics as implemented by Chrome, however.