### PR TITLE
fix(dom): intersect defaultView with globalThis

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4607,7 +4607,7 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      * Returns null if the Document is not currently executing a script or SVG script element (e.g., because the running script is an event handler, or a timeout), or if the currently executing script or SVG script element represents a module script.
      */
     readonly currentScript: HTMLOrSVGScriptElement | null;
-    readonly defaultView: WindowProxy | null;
+    readonly defaultView: (WindowProxy & typeof globalThis) | null;
     /**
      * Sets or gets a value that indicates whether the document can be edited.
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -596,6 +596,10 @@
                 },
                 "properties": {
                     "property": {
+                        "defaultView": {
+                            "name": "defaultView",
+                            "override-type": "(WindowProxy & typeof globalThis) | null"
+                        },
                         "documentElement": {
                             "name": "documentElement",
                             "override-type": "HTMLElement",


### PR DESCRIPTION
Follow-up to #715

With #819 this change allows 
```ts
declare const element: Element;
const isInput = element instanceof element.ownerDocument.defaultView!.HTMLInputElement;
```

Still requires non-null assertion which is fine. Above code will never be sound since defaultView might not be available. This is, at least for my purpose, alright.
Currently I simply have to `@ts-ignore` `element.ownerDocument.defaultView.HTMLInputElement`.

