### PR TITLE
Add Media Session types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -669,6 +669,12 @@ interface MediaEncryptedEventInit extends EventInit {
     initDataType?: string;
 }
 
+interface MediaImage {
+    sizes?: string;
+    src: string;
+    type?: string;
+}
+
 interface MediaKeyMessageEventInit extends EventInit {
     message: ArrayBuffer;
     messageType: MediaKeyMessageType;
@@ -689,9 +695,26 @@ interface MediaKeySystemMediaCapability {
     robustness?: string;
 }
 
+interface MediaMetadataInit {
+    album?: string;
+    artist?: string;
+    artwork?: MediaImage[];
+    title?: string;
+}
+
+interface MediaPositionState {
+    duration?: number;
+    playbackRate?: number;
+    position?: number;
+}
+
 interface MediaQueryListEventInit extends EventInit {
     matches?: boolean;
     media?: string;
+}
+
+interface MediaSessionActionDetails {
+    action: MediaSessionAction;
 }
 
 interface MediaStreamAudioSourceOptions {
@@ -10419,6 +10442,18 @@ declare var MediaList: {
     new(): MediaList;
 };
 
+interface MediaMetadata {
+    album: string;
+    artist: string;
+    artwork: ReadonlyArray<MediaImage>;
+    title: string;
+}
+
+declare var MediaMetadata: {
+    prototype: MediaMetadata;
+    new(init?: MediaMetadataInit): MediaMetadata;
+};
+
 interface MediaQueryListEventMap {
     "change": MediaQueryListEvent;
 }
@@ -10451,6 +10486,18 @@ interface MediaQueryListEvent extends Event {
 declare var MediaQueryListEvent: {
     prototype: MediaQueryListEvent;
     new(type: string, eventInitDict?: MediaQueryListEventInit): MediaQueryListEvent;
+};
+
+interface MediaSession {
+    metadata: MediaMetadata | null;
+    playbackState: MediaSessionPlaybackState;
+    setActionHandler(action: MediaSessionAction, handler: MediaSessionActionHandler | null): void;
+    setPositionState(state?: MediaPositionState): void;
+}
+
+declare var MediaSession: {
+    prototype: MediaSession;
+    new(): MediaSession;
 };
 
 interface MediaSourceEventMap {
@@ -10897,6 +10944,7 @@ interface Navigator extends MSFileSaver, MSNavigatorDoNotTrack, NavigatorAutomat
     readonly geolocation: Geolocation;
     readonly maxTouchPoints: number;
     readonly mediaDevices: MediaDevices;
+    readonly mediaSession: MediaSession;
     readonly msManipulationViewsEnabled: boolean;
     readonly msMaxTouchPoints: number;
     readonly msPointerEnabled: boolean;
@@ -19290,6 +19338,10 @@ interface MSLaunchUriCallback {
     (): void;
 }
 
+interface MediaSessionActionHandler {
+    (details: MediaSessionActionDetails): void;
+}
+
 interface MutationCallback {
     (mutations: MutationRecord[], observer: MutationObserver): void;
 }
@@ -20126,6 +20178,8 @@ type MediaKeyMessageType = "individualization-request" | "license-release" | "li
 type MediaKeySessionType = "persistent-license" | "temporary";
 type MediaKeyStatus = "expired" | "internal-error" | "output-downscaled" | "output-restricted" | "released" | "status-pending" | "usable";
 type MediaKeysRequirement = "not-allowed" | "optional" | "required";
+type MediaSessionAction = "nexttrack" | "pause" | "play" | "previoustrack" | "seekbackward" | "seekforward" | "seekto" | "skipad" | "stop";
+type MediaSessionPlaybackState = "none" | "paused" | "playing";
 type MediaStreamTrackState = "ended" | "live";
 type NavigationReason = "down" | "left" | "right" | "up";
 type NavigationType = "back_forward" | "navigate" | "prerender" | "reload";

--- a/inputfiles/idl/Media Session.widl
+++ b/inputfiles/idl/Media Session.widl
@@ -1,0 +1,76 @@
+[Exposed=Window]
+partial interface Navigator {
+  [SameObject] readonly attribute MediaSession mediaSession;
+};
+
+enum MediaSessionPlaybackState {
+  "none",
+  "paused",
+  "playing"
+};
+
+enum MediaSessionAction {
+  "play",
+  "pause",
+  "seekbackward",
+  "seekforward",
+  "previoustrack",
+  "nexttrack",
+  "skipad",
+  "stop",
+  "seekto"
+};
+
+callback MediaSessionActionHandler = void(MediaSessionActionDetails details);
+
+[Exposed=Window]
+interface MediaSession {
+  attribute MediaMetadata? metadata;
+
+  attribute MediaSessionPlaybackState playbackState;
+
+  void setActionHandler(MediaSessionAction action, MediaSessionActionHandler? handler);
+
+  void setPositionState(optional MediaPositionState state = {});
+};
+
+[Exposed=Window]
+interface MediaMetadata {
+  constructor(optional MediaMetadataInit init = {});
+  attribute DOMString title;
+  attribute DOMString artist;
+  attribute DOMString album;
+  attribute FrozenArray<MediaImage> artwork;
+};
+
+dictionary MediaMetadataInit {
+  DOMString title = "";
+  DOMString artist = "";
+  DOMString album = "";
+  sequence<MediaImage> artwork = [];
+};
+
+dictionary MediaImage {
+  required USVString src;
+  DOMString sizes = "";
+  DOMString type = "";
+};
+
+dictionary MediaPositionState {
+  double duration;
+  double playbackRate;
+  double position;
+};
+
+dictionary MediaSessionActionDetails {
+  required MediaSessionAction action;
+};
+
+dictionary MediaSessionSeekActionDetails : MediaSessionActionDetails {
+  double? seekOffset;
+};
+
+dictionary MediaSessionSeekToActionDetails : MediaSessionActionDetails {
+  required double seekTime;
+  boolean? fastSeek;
+};

--- a/inputfiles/idlSources.json
+++ b/inputfiles/idlSources.json
@@ -359,6 +359,10 @@
         "title": "Media Capture and Streams"
     },
     {
+        "url": "https://www.w3.org/TR/mediasession/",
+        "title": "Media Session"
+    },
+    {
         "url": "https://www.w3.org/TR/media-source/",
         "title": "Media Source Extensions"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -877,9 +877,9 @@
       }
     },
     "typescript": {
-      "version": "3.8.0-dev.20191123",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20191123.tgz",
-      "integrity": "sha512-1Cz/SejVZuU8F8aYlOS7wfXaBxwQ11iARAkZvwbdHVkFjYiaI3E1f//QKsBiP7IYKZp+J5EEDcUoZxYihw2IqA=="
+      "version": "3.8.0-dev.20200208",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.0-dev.20200208.tgz",
+      "integrity": "sha512-/n4f+RIfoHvEmXprHjE7dHzGlDzD0wpqpvHBXBtwaCi1wp8zsGqA07v1UPijR1xBqumO5FFDMEPIuu7fEDJemA=="
     },
     "universalify": {
       "version": "0.1.2",


### PR DESCRIPTION
This adds types for the [Media Session API](https://developer.mozilla.org/en-US/docs/Web/API/Media_Session_API).

The only thing that could be improved with the types is that:
```ts
interface MediaSession {
    setActionHandler(action: MediaSessionAction, handler: MediaSessionActionHandler | null): void;
}

interface MediaSessionActionHandler {
    (details: MediaSessionActionDetails): void;
}
```
should really be:
```ts
interface MediaSession {
    setActionHandler(action: 'seekbackward' | 'seekforward', handler: MediaSessionSeekActionHandler | null): void;
    setActionHandler(action: 'seekto', handler: MediaSessionSeekToActionHandler | null): void;
    setActionHandler(action: MediaSessionAction, handler: MediaSessionActionHandler | null): void;
}

interface MediaSessionActionHandler {
    (details: MediaSessionActionDetails): void;
}

interface MediaSessionSeekActionHandler {
    (details: MediaSessionSeekActionDetails): void;
}

interface MediaSessionSeekToActionHandler {
    (details: MediaSessionSeekToActionDetails): void;
}
```

But I couldn't figure out how to insert the additional interfaces and the `MediaSessionSeekActionDetails` and `MediaSessionSeekToActionDetails` types from the widl file.