### PR TITLE
Add WritableStream.close()

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -18827,6 +18827,7 @@ declare var Worklet: {
 interface WritableStream<W = any> {
     readonly locked: boolean;
     abort(reason?: any): Promise<void>;
+    close(): Promise<void>;
     getWriter(): WritableStreamDefaultWriter<W>;
 }
 

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -5469,6 +5469,7 @@ interface WorkerUtils extends WindowBase64 {
 interface WritableStream<W = any> {
     readonly locked: boolean;
     abort(reason?: any): Promise<void>;
+    close(): Promise<void>;
     getWriter(): WritableStreamDefaultWriter<W>;
 }
 

--- a/inputfiles/idl/Streams.widl
+++ b/inputfiles/idl/Streams.widl
@@ -114,6 +114,7 @@ interface ReadableStreamBYOBRequest {
 interface WritableStream {
     readonly attribute boolean locked;
     Promise<void> abort(optional any reason);
+    Promise<void> close();
     WritableStreamDefaultWriter getWriter();
 };
 


### PR DESCRIPTION
The streams standard [has added](https://github.com/whatwg/streams/commit/547428be7c067156a15a8762ff9933193befc753) a new shorthand method to close a writable stream: [WritableStream.close()](https://streams.spec.whatwg.org/#ws-close). It's [already implemented in Chrome 81](https://chromestatus.com/feature/5440098147500032).