### PR TITLE
fix(NamedNodeMap): Index signature accepts `string`

### DIFF
--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -783,6 +783,12 @@
                     ]
                 }
             },
+            "NamedNodeMap": {
+                "override-index-signatures": [
+                    "[name: string]: Attr",
+                    "[index: number]: Attr"
+                ]
+            },
             "Navigator": {
                 "name": "Navigator",
                 "methods": {


### PR DESCRIPTION
See the [**DOM Specification**](https://dom.spec.whatwg.org/#interface-namednodemap) for details.