### PR TITLE
Remove Gecko specific Navigator members

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -10942,14 +10942,12 @@ interface NavigatorID {
     readonly appCodeName: string;
     readonly appName: string;
     readonly appVersion: string;
-    readonly oscpu: string;
     readonly platform: string;
     readonly product: string;
     readonly productSub: string;
     readonly userAgent: string;
     readonly vendor: string;
     readonly vendorSub: string;
-    taintEnabled(): boolean;
 }
 
 interface NavigatorLanguage {

--- a/inputfiles/removedTypes.json
+++ b/inputfiles/removedTypes.json
@@ -22,6 +22,18 @@
                     }
                 }
             },
+            "NavigatorID": {
+                "methods": {
+                    "method": {
+                        "taintEnabled": null
+                    }
+                },
+                "properties": {
+                    "property": {
+                        "oscpu": null
+                    }
+                }
+            },
             "XMLHttpRequestEventTarget": null,
             "WorkerUtils": {
                 "methods": {


### PR DESCRIPTION
Fixes #748 

As described in https://html.spec.whatwg.org/multipage/system-state.html#NavigatorID-partial, this is only available by default in Firefox.