### PR TITLE
Fix duplicates after merge in addedTypes.json

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -7552,7 +7552,7 @@ declare var HTMLMarqueeElement: {
 };
 
 interface HTMLMediaElementEventMap extends HTMLElementEventMap {
-    "encrypted": Event;
+    "encrypted": MediaEncryptedEvent;
     "waitingforkey": Event;
 }
 
@@ -7609,7 +7609,7 @@ interface HTMLMediaElement extends HTMLElement {
      * Gets the current network activity for the element.
      */
     readonly networkState: number;
-    onencrypted: ((this: HTMLMediaElement, ev: Event) => any) | null;
+    onencrypted: ((this: HTMLMediaElement, ev: MediaEncryptedEvent) => any) | null;
     onwaitingforkey: ((this: HTMLMediaElement, ev: Event) => any) | null;
     /**
      * Gets a flag that specifies whether playback is paused.
@@ -19360,12 +19360,14 @@ interface HTMLElementTagNameMap {
     "area": HTMLAreaElement;
     "article": HTMLElement;
     "aside": HTMLElement;
+    "audio": HTMLAudioElement;
     "b": HTMLElement;
     "base": HTMLBaseElement;
     "basefont": HTMLBaseFontElement;
     "bdi": HTMLElement;
     "bdo": HTMLElement;
     "blockquote": HTMLQuoteElement;
+    "body": HTMLBodyElement;
     "br": HTMLBRElement;
     "button": HTMLButtonElement;
     "canvas": HTMLCanvasElement;
@@ -19395,6 +19397,12 @@ interface HTMLElementTagNameMap {
     "form": HTMLFormElement;
     "frame": HTMLFrameElement;
     "frameset": HTMLFrameSetElement;
+    "h1": HTMLHeadingElement;
+    "h2": HTMLHeadingElement;
+    "h3": HTMLHeadingElement;
+    "h4": HTMLHeadingElement;
+    "h5": HTMLHeadingElement;
+    "h6": HTMLHeadingElement;
     "head": HTMLHeadElement;
     "header": HTMLElement;
     "hgroup": HTMLElement;
@@ -19458,9 +19466,11 @@ interface HTMLElementTagNameMap {
     "time": HTMLTimeElement;
     "title": HTMLTitleElement;
     "tr": HTMLTableRowElement;
+    "track": HTMLTrackElement;
     "u": HTMLElement;
     "ul": HTMLUListElement;
     "var": HTMLElement;
+    "video": HTMLVideoElement;
     "wbr": HTMLElement;
 }
 

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -416,6 +416,16 @@
                             "type": "MediaEncryptedEvent"
                         }
                     ]
+                },
+                "methods": {
+                    "method": {
+                        "cloneNode": {
+                            "name": "cloneNode",
+                            "override-signatures": [
+                                "cloneNode(deep?: boolean): HTMLMediaElement"
+                            ]
+                        }
+                    }
                 }
             },
             "CSSStyleDeclaration": {
@@ -1277,7 +1287,17 @@
                     {
                         "name": "audio"
                     }
-                ]
+                ],
+                "methods": {
+                    "method": {
+                        "cloneNode": {
+                            "name": "cloneNode",
+                            "override-signatures": [
+                                "cloneNode(deep?: boolean): HTMLAudioElement"
+                            ]
+                        }
+                    }
+                }
             },
             "HTMLBaseElement": {
                 "element": [
@@ -1301,7 +1321,17 @@
                     {
                         "name": "body"
                     }
-                ]
+                ],
+                "methods": {
+                    "method": {
+                        "cloneNode": {
+                            "name": "cloneNode",
+                            "override-signatures": [
+                                "cloneNode(deep?: boolean): HTMLBodyElement"
+                            ]
+                        }
+                    }
+                }
             },
             "HTMLBRElement": {
                 "element": [
@@ -1607,7 +1637,17 @@
                     {
                         "name": "h6"
                     }
-                ]
+                ],
+                "methods": {
+                    "method": {
+                        "cloneNode": {
+                            "name": "cloneNode",
+                            "override-signatures": [
+                                "cloneNode(deep?: boolean): HTMLHeadingElement"
+                            ]
+                        }
+                    }
+                }
             },
             "HTMLHRElement": {
                 "element": [
@@ -2232,7 +2272,17 @@
                     {
                         "name": "track"
                     }
-                ]
+                ],
+                "methods": {
+                    "method": {
+                        "cloneNode": {
+                            "name": "cloneNode",
+                            "override-signatures": [
+                                "cloneNode(deep?: boolean): HTMLTrackElement"
+                            ]
+                        }
+                    }
+                }
             },
             "HTMLUListElement": {
                 "element": [
@@ -3401,19 +3451,6 @@
                     }
                 }
             },
-            "HTMLAudioElement": {
-                "name": "HTMLAudioElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLAudioElement"
-                            ]
-                        }
-                    }
-                }
-            },
             "HTMLBaseFontElement": {
                 "name": "HTMLBaseFontElement",
                 "methods": {
@@ -3422,19 +3459,6 @@
                             "name": "cloneNode",
                             "override-signatures": [
                                 "cloneNode(deep?: boolean): HTMLBaseFontElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLBodyElement": {
-                "name": "HTMLBodyElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLBodyElement"
                             ]
                         }
                     }
@@ -3544,19 +3568,6 @@
                     }
                 }
             },
-            "HTMLHeadingElement": {
-                "name": "HTMLHeadingElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLHeadingElement"
-                            ]
-                        }
-                    }
-                }
-            },
             "HTMLLegendElement": {
                 "name": "HTMLLegendElement",
                 "methods": {
@@ -3578,19 +3589,6 @@
                             "name": "cloneNode",
                             "override-signatures": [
                                 "cloneNode(deep?: boolean): HTMLMarqueeElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLMediaElement": {
-                "name": "HTMLMediaElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMediaElement"
                             ]
                         }
                     }
@@ -3674,19 +3672,6 @@
                     }
                 }
             },
-            "HTMLTrackElement": {
-                "name": "HTMLTrackElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTrackElement"
-                            ]
-                        }
-                    }
-                }
-            },
             "HTMLUnknownElement": {
                 "name": "HTMLUnknownElement",
                 "methods": {
@@ -3695,19 +3680,6 @@
                             "name": "cloneNode",
                             "override-signatures": [
                                 "cloneNode(deep?: boolean): HTMLUnknownElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLVideoElement": {
-                "name": "HTMLVideoElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLVideoElement"
                             ]
                         }
                     }


### PR DESCRIPTION
Noticed that there are problems with in `addedTypes.json` (thanks VS Code!) which were related to duplicated entries in `interfaces` > `interface`.

I've removed blocks with `cloneNode` and re-run patched helper script to bring them back to existing nodes.

Updated baselines should now contain proper overrides and elements names that were skipped because of duplicated keys later in JSON.

Related to #811