### PR TITLE
Update DOM types

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4533,10 +4533,6 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
      */
     onreadystatechange: ((this: Document, ev: Event) => any) | null;
     onvisibilitychange: ((this: Document, ev: Event) => any) | null;
-    /**
-     * Returns document's origin.
-     */
-    readonly origin: string;
     readonly ownerDocument: null;
     /**
      * Return an HTMLCollection of the embed elements in the Document.
@@ -5072,7 +5068,7 @@ interface ElementEventMap {
 }
 
 /** Element is the most general base class from which all objects in a Document inherit. It only has methods and properties common to all kinds of elements. More specific classes inherit from Element. */
-interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTypeChildNode, ParentNode, Slotable {
+interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTypeChildNode, ParentNode, Slottable {
     readonly assignedSlot: HTMLSlotElement | null;
     readonly attributes: NamedNodeMap;
     /**
@@ -15117,7 +15113,7 @@ declare var SharedWorker: {
     new(scriptURL: string, options?: string | WorkerOptions): SharedWorker;
 };
 
-interface Slotable {
+interface Slottable {
     readonly assignedSlot: HTMLSlotElement | null;
 }
 
@@ -15559,7 +15555,7 @@ declare var SyncManager: {
 };
 
 /** The textual content of Element or Attr. If an element has no markup within its content, it has a single child implementing Text that contains the element's text. However, if the element contains markup, it is parsed into information items and Text nodes that form its children. */
-interface Text extends CharacterData, Slotable {
+interface Text extends CharacterData, Slottable {
     readonly assignedSlot: HTMLSlotElement | null;
     /**
      * Returns the combined data of all direct Text node siblings.

--- a/inputfiles/idl/DOM.commentmap.json
+++ b/inputfiles/idl/DOM.commentmap.json
@@ -79,7 +79,6 @@
     "document-implementation": "Returns document's DOMImplementation object.",
     "document-url": "Returns document's URL.",
     "document-documenturi": "Returns document's URL.",
-    "document-origin": "Returns document's origin.",
     "document-compatmode": "Returns the string \"BackCompat\" if document's mode is \"quirks\", and \"CSS1Compat\" otherwise.",
     "document-characterset": "Returns document's encoding.",
     "document-contenttype": "Returns document's content type.",

--- a/inputfiles/idl/DOM.widl
+++ b/inputfiles/idl/DOM.widl
@@ -47,7 +47,7 @@ interface CustomEvent : Event {
 
   readonly attribute any detail;
 
-  void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null);
+  void initCustomEvent(DOMString type, optional boolean bubbles = false, optional boolean cancelable = false, optional any detail = null); // historical
 };
 
 dictionary CustomEventInit : EventInit {
@@ -136,11 +136,11 @@ DocumentType includes ChildNode;
 Element includes ChildNode;
 CharacterData includes ChildNode;
 
-interface mixin Slotable {
+interface mixin Slottable {
   readonly attribute HTMLSlotElement? assignedSlot;
 };
-Element includes Slotable;
-Text includes Slotable;
+Element includes Slottable;
+Text includes Slottable;
 
 [Exposed=Window]
 interface NodeList {
@@ -259,7 +259,6 @@ interface Document : Node {
   [SameObject] readonly attribute DOMImplementation implementation;
   readonly attribute USVString URL;
   readonly attribute USVString documentURI;
-  readonly attribute USVString origin;
   readonly attribute DOMString compatMode;
   readonly attribute DOMString characterSet;
   readonly attribute DOMString charset; // historical alias of .characterSet
@@ -286,7 +285,7 @@ interface Document : Node {
   [NewObject] Attr createAttribute(DOMString localName);
   [NewObject] Attr createAttributeNS(DOMString? namespace, DOMString qualifiedName);
 
-  [NewObject] Event createEvent(DOMString interface);
+  [NewObject] Event createEvent(DOMString interface); // historical
 
   [NewObject] Range createRange();
 


### PR DESCRIPTION
`document.origin` has been marked as obsolete and now is removed from the spec. Firefox and Chrome dropped the support, while Safari still supports it.

The IDL change marks `initCustomEvent` and `createEvent` as historical, should they marked as `@deprecated`? Previously the answer was yes (as we mark the whole Compatibility spec as `@deprecated` and also several others), but maybe time to make sure again.