### PR TITLE
Fix the HTMLElement constructor override

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -19232,7 +19232,7 @@ interface BlobCallback {
 }
 
 interface CustomElementConstructor {
-    new (...params:[]): HTMLElement;
+    new (...params: any[]): HTMLElement;
 }
 
 interface DecodeErrorCallback {

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -314,7 +314,7 @@
             },
             "CustomElementConstructor": {
                 "override-signatures": [
-                    "new (...params:[]): HTMLElement"
+                    "new (...params: any[]): HTMLElement"
                 ]
             }
         }


### PR DESCRIPTION
From specifically a `[]` (a 0 length tuple) to an `any[]`