### PR TITLE
Remove clone node overrides

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -2176,7 +2176,6 @@ interface Attr extends Node {
     readonly prefix: string | null;
     readonly specified: boolean;
     value: string;
-    cloneNode(deep?: boolean): Attr;
 }
 
 declare var Attr: {
@@ -2583,7 +2582,6 @@ declare var ByteLengthQueuingStrategy: {
 
 /** A CDATA section that can be used within XML to include extended portions of unescaped text. The symbols < and & don’t need escaping as they normally do when inside a CDATA section. */
 interface CDATASection extends Text {
-    cloneNode(deep?: boolean): CDATASection;
 }
 
 declare var CDATASection: {
@@ -3463,7 +3461,6 @@ interface CharacterData extends Node, ChildNode, NonDocumentTypeChildNode {
     readonly length: number;
     readonly ownerDocument: Document;
     appendData(data: string): void;
-    cloneNode(deep?: boolean): CharacterData;
     deleteData(offset: number, count: number): void;
     insertData(offset: number, data: string): void;
     replaceData(offset: number, count: number, data: string): void;
@@ -3568,7 +3565,6 @@ declare var CloseEvent: {
 
 /** Textual notations within markup; although it is generally not visually shown, such comments are available to be read in the source view. */
 interface Comment extends CharacterData {
-    cloneNode(deep?: boolean): Comment;
 }
 
 declare var Comment: {
@@ -4579,7 +4575,6 @@ interface Document extends Node, DocumentAndElementEventHandlers, DocumentOrShad
     caretRangeFromPoint(x: number, y: number): Range;
     /** @deprecated */
     clear(): void;
-    cloneNode(deep?: boolean): Document;
     /**
      * Closes an output stream and forces the sent data to display.
      */
@@ -4963,7 +4958,6 @@ interface DocumentEvent {
 /** A minimal document object that has no parent. It is used as a lightweight version of Document that stores a segment of a document structure comprised of nodes just like a standard document. The key difference is that because the document fragment isn't part of the active document tree structure, changes made to the fragment don't affect the document, cause reflow, or incur any performance impact that can occur when changes are made. */
 interface DocumentFragment extends Node, NonElementParentNode, ParentNode {
     readonly ownerDocument: Document;
-    cloneNode(deep?: boolean): DocumentFragment;
     getElementById(elementId: string): HTMLElement | null;
 }
 
@@ -5005,7 +4999,6 @@ interface DocumentType extends Node, ChildNode {
     readonly ownerDocument: Document;
     readonly publicId: string;
     readonly systemId: string;
-    cloneNode(deep?: boolean): DocumentType;
 }
 
 declare var DocumentType: {
@@ -5127,7 +5120,6 @@ interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTyp
      * Creates a shadow root for element and returns it.
      */
     attachShadow(init: ShadowRootInit): ShadowRoot;
-    cloneNode(deep?: boolean): Element;
     /**
      * Returns the first (starting at element) inclusive ancestor that matches selectors, and null otherwise.
      */
@@ -6091,7 +6083,6 @@ interface HTMLAnchorElement extends HTMLElement, HTMLHyperlinkElementUtils {
      */
     text: string;
     type: string;
-    cloneNode(deep?: boolean): HTMLAnchorElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAnchorElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAnchorElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6142,7 +6133,6 @@ interface HTMLAppletElement extends HTMLElement {
     vspace: number;
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLAppletElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAppletElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAppletElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6182,7 +6172,6 @@ interface HTMLAreaElement extends HTMLElement, HTMLHyperlinkElementUtils {
      * Sets or retrieves the window or frame at which to target content.
      */
     target: string;
-    cloneNode(deep?: boolean): HTMLAreaElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLAreaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6196,7 +6185,6 @@ declare var HTMLAreaElement: {
 
 /** Provides access to the properties of <audio> elements, as well as methods to manipulate them. It derives from the HTMLMediaElement interface. */
 interface HTMLAudioElement extends HTMLMediaElement {
-    cloneNode(deep?: boolean): HTMLAudioElement;
     addEventListener<K extends keyof HTMLMediaElementEventMap>(type: K, listener: (this: HTMLAudioElement, ev: HTMLMediaElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLMediaElementEventMap>(type: K, listener: (this: HTMLAudioElement, ev: HTMLMediaElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6215,7 +6203,6 @@ interface HTMLBRElement extends HTMLElement {
      */
     /** @deprecated */
     clear: string;
-    cloneNode(deep?: boolean): HTMLBRElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBRElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBRElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6237,7 +6224,6 @@ interface HTMLBaseElement extends HTMLElement {
      * Sets or retrieves the window or frame at which to target content.
      */
     target: string;
-    cloneNode(deep?: boolean): HTMLBaseElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6261,7 +6247,6 @@ interface HTMLBaseFontElement extends HTMLElement, DOML2DeprecatedColorProperty 
      */
     /** @deprecated */
     size: number;
-    cloneNode(deep?: boolean): HTMLBaseFontElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLBaseFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6293,7 +6278,6 @@ interface HTMLBodyElement extends HTMLElement, WindowEventHandlers {
     text: string;
     /** @deprecated */
     vLink: string;
-    cloneNode(deep?: boolean): HTMLBodyElement;
     addEventListener<K extends keyof HTMLBodyElementEventMap>(type: K, listener: (this: HTMLBodyElement, ev: HTMLBodyElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLBodyElementEventMap>(type: K, listener: (this: HTMLBodyElement, ev: HTMLBodyElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6361,7 +6345,6 @@ interface HTMLButtonElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLButtonElement;
     reportValidity(): boolean;
     /**
      * Sets a custom error message that is displayed when a form is submitted.
@@ -6389,7 +6372,6 @@ interface HTMLCanvasElement extends HTMLElement {
      * Gets or sets the width of a canvas element on a document.
      */
     width: number;
-    cloneNode(deep?: boolean): HTMLCanvasElement;
     /**
      * Returns an object that provides methods and properties for drawing and manipulating images and graphics on a canvas element in a document. A context object includes information about colors, line widths, fonts, and other graphic parameters that can be drawn on a canvas.
      * @param contextId The identifier (ID) of the type of canvas to create. Internet Explorer 9 and Internet Explorer 10 support only a 2-D context using canvas.getContext("2d"); IE11 Preview also supports 3-D or WebGL context using canvas.getContext("experimental-webgl");
@@ -6452,7 +6434,6 @@ interface HTMLCollectionOf<T extends Element> extends HTMLCollectionBase {
 interface HTMLDListElement extends HTMLElement {
     /** @deprecated */
     compact: boolean;
-    cloneNode(deep?: boolean): HTMLDListElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6467,7 +6448,6 @@ declare var HTMLDListElement: {
 /** Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <data> elements. */
 interface HTMLDataElement extends HTMLElement {
     value: string;
-    cloneNode(deep?: boolean): HTMLDataElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDataElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDataElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6482,7 +6462,6 @@ declare var HTMLDataElement: {
 /** Provides special properties (beyond the HTMLElement object interface it also has available to it by inheritance) to manipulate <datalist> elements and their content. */
 interface HTMLDataListElement extends HTMLElement {
     readonly options: HTMLCollectionOf<HTMLOptionElement>;
-    cloneNode(deep?: boolean): HTMLDataListElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDataListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDataListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6496,7 +6475,6 @@ declare var HTMLDataListElement: {
 
 interface HTMLDetailsElement extends HTMLElement {
     open: boolean;
-    cloneNode(deep?: boolean): HTMLDetailsElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDetailsElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDetailsElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6511,7 +6489,6 @@ declare var HTMLDetailsElement: {
 interface HTMLDialogElement extends HTMLElement {
     open: boolean;
     returnValue: string;
-    cloneNode(deep?: boolean): HTMLDialogElement;
     close(returnValue?: string): void;
     show(): void;
     showModal(): void;
@@ -6529,7 +6506,6 @@ declare var HTMLDialogElement: {
 interface HTMLDirectoryElement extends HTMLElement {
     /** @deprecated */
     compact: boolean;
-    cloneNode(deep?: boolean): HTMLDirectoryElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDirectoryElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDirectoryElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6548,7 +6524,6 @@ interface HTMLDivElement extends HTMLElement {
      */
     /** @deprecated */
     align: string;
-    cloneNode(deep?: boolean): HTMLDivElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDivElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLDivElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6562,7 +6537,6 @@ declare var HTMLDivElement: {
 
 /** The HTMLDocument property of Window objects is an alias that browsers expose for the Document interface object. */
 interface HTMLDocument extends Document {
-    cloneNode(deep?: boolean): HTMLDocument;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: HTMLDocument, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: HTMLDocument, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6596,7 +6570,6 @@ interface HTMLElement extends Element, DocumentAndElementEventHandlers, ElementC
     title: string;
     translate: boolean;
     click(): void;
-    cloneNode(deep?: boolean): HTMLElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6630,7 +6603,6 @@ interface HTMLEmbedElement extends HTMLElement {
      * Sets or retrieves the width of the object.
      */
     width: string;
-    cloneNode(deep?: boolean): HTMLEmbedElement;
     getSVGDocument(): Document | null;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLEmbedElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -6669,7 +6641,6 @@ interface HTMLFieldSetElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLFieldSetElement;
     reportValidity(): boolean;
     /**
      * Sets a custom error message that is displayed when a form is submitted.
@@ -6698,7 +6669,6 @@ interface HTMLFontElement extends HTMLElement {
     face: string;
     /** @deprecated */
     size: string;
-    cloneNode(deep?: boolean): HTMLFontElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLFontElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6775,7 +6745,6 @@ interface HTMLFormElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLFormElement;
     reportValidity(): boolean;
     /**
      * Fires when the user resets a form.
@@ -6849,7 +6818,6 @@ interface HTMLFrameElement extends HTMLElement {
      */
     /** @deprecated */
     src: string;
-    cloneNode(deep?: boolean): HTMLFrameElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLFrameElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLFrameElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6876,7 +6844,6 @@ interface HTMLFrameSetElement extends HTMLElement, WindowEventHandlers {
      */
     /** @deprecated */
     rows: string;
-    cloneNode(deep?: boolean): HTMLFrameSetElement;
     addEventListener<K extends keyof HTMLFrameSetElementEventMap>(type: K, listener: (this: HTMLFrameSetElement, ev: HTMLFrameSetElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLFrameSetElementEventMap>(type: K, listener: (this: HTMLFrameSetElement, ev: HTMLFrameSetElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6909,7 +6876,6 @@ interface HTMLHRElement extends HTMLElement {
      */
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLHRElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHRElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHRElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6923,7 +6889,6 @@ declare var HTMLHRElement: {
 
 /** Contains the descriptive information, or metadata, for a document. This object inherits all of the properties and methods described in the HTMLElement interface. */
 interface HTMLHeadElement extends HTMLElement {
-    cloneNode(deep?: boolean): HTMLHeadElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6942,7 +6907,6 @@ interface HTMLHeadingElement extends HTMLElement {
      */
     /** @deprecated */
     align: string;
-    cloneNode(deep?: boolean): HTMLHeadingElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadingElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHeadingElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -6961,7 +6925,6 @@ interface HTMLHtmlElement extends HTMLElement {
      */
     /** @deprecated */
     version: string;
-    cloneNode(deep?: boolean): HTMLHtmlElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHtmlElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLHtmlElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7053,7 +7016,6 @@ interface HTMLIFrameElement extends HTMLElement {
      * Sets or retrieves the width of the object.
      */
     width: string;
-    cloneNode(deep?: boolean): HTMLIFrameElement;
     getSVGDocument(): Document | null;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLIFrameElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -7144,7 +7106,6 @@ interface HTMLImageElement extends HTMLElement {
     width: number;
     readonly x: number;
     readonly y: number;
-    cloneNode(deep?: boolean): HTMLImageElement;
     decode(): Promise<void>;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLImageElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -7321,7 +7282,6 @@ interface HTMLInputElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLInputElement;
     reportValidity(): boolean;
     /**
      * Makes the selection equal to the current object.
@@ -7370,7 +7330,6 @@ interface HTMLLIElement extends HTMLElement {
      * Sets or retrieves the value of a list item.
      */
     value: number;
-    cloneNode(deep?: boolean): HTMLLIElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLIElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLIElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7393,7 +7352,6 @@ interface HTMLLabelElement extends HTMLElement {
      * Sets or retrieves the object to which the given label object is assigned.
      */
     htmlFor: string;
-    cloneNode(deep?: boolean): HTMLLabelElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLabelElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLabelElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7413,7 +7371,6 @@ interface HTMLLegendElement extends HTMLElement {
      * Retrieves a reference to the form that the object is embedded in.
      */
     readonly form: HTMLFormElement | null;
-    cloneNode(deep?: boolean): HTMLLegendElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLegendElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLegendElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7471,7 +7428,6 @@ interface HTMLLinkElement extends HTMLElement, LinkStyle {
      * Sets or retrieves the MIME type of the object.
      */
     type: string;
-    cloneNode(deep?: boolean): HTMLLinkElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLinkElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLLinkElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7493,7 +7449,6 @@ interface HTMLMapElement extends HTMLElement {
      * Sets or retrieves the name of the object.
      */
     name: string;
-    cloneNode(deep?: boolean): HTMLMapElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMapElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMapElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7541,7 +7496,6 @@ interface HTMLMarqueeElement extends HTMLElement {
     vspace: number;
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLMarqueeElement;
     /** @deprecated */
     start(): void;
     /** @deprecated */
@@ -7657,7 +7611,6 @@ interface HTMLMediaElement extends HTMLElement {
      * Returns a string that specifies whether the client can play a given media resource type.
      */
     canPlayType(type: string): CanPlayTypeResult;
-    cloneNode(deep?: boolean): HTMLMediaElement;
     fastSeek(time: number): void;
     /**
      * Resets the audio or video object and loads a new media resource.
@@ -7704,7 +7657,6 @@ declare var HTMLMediaElement: {
 interface HTMLMenuElement extends HTMLElement {
     /** @deprecated */
     compact: boolean;
-    cloneNode(deep?: boolean): HTMLMenuElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMenuElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMenuElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7735,7 +7687,6 @@ interface HTMLMetaElement extends HTMLElement {
      */
     /** @deprecated */
     scheme: string;
-    cloneNode(deep?: boolean): HTMLMetaElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMetaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMetaElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7756,7 +7707,6 @@ interface HTMLMeterElement extends HTMLElement {
     min: number;
     optimum: number;
     value: number;
-    cloneNode(deep?: boolean): HTMLMeterElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMeterElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLMeterElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7778,7 +7728,6 @@ interface HTMLModElement extends HTMLElement {
      * Sets or retrieves the date and time of a modification to the object.
      */
     dateTime: string;
-    cloneNode(deep?: boolean): HTMLModElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLModElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLModElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7800,7 +7749,6 @@ interface HTMLOListElement extends HTMLElement {
      */
     start: number;
     type: string;
-    cloneNode(deep?: boolean): HTMLOListElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7898,7 +7846,6 @@ interface HTMLObjectElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLObjectElement;
     getSVGDocument(): Document | null;
     reportValidity(): boolean;
     /**
@@ -7928,7 +7875,6 @@ interface HTMLOptGroupElement extends HTMLElement {
      * Sets or retrieves a value that you can use to implement your own label functionality for the object.
      */
     label: string;
-    cloneNode(deep?: boolean): HTMLOptGroupElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOptGroupElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOptGroupElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -7971,7 +7917,6 @@ interface HTMLOptionElement extends HTMLElement {
      * Sets or retrieves the value which is returned to the server when the form control is submitted.
      */
     value: string;
-    cloneNode(deep?: boolean): HTMLOptionElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOptionElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOptionElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8042,7 +7987,6 @@ interface HTMLOutputElement extends HTMLElement {
     value: string;
     readonly willValidate: boolean;
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLOutputElement;
     reportValidity(): boolean;
     setCustomValidity(error: string): void;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLOutputElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
@@ -8063,7 +8007,6 @@ interface HTMLParagraphElement extends HTMLElement {
      */
     /** @deprecated */
     align: string;
-    cloneNode(deep?: boolean): HTMLParagraphElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLParagraphElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLParagraphElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8095,7 +8038,6 @@ interface HTMLParamElement extends HTMLElement {
      */
     /** @deprecated */
     valueType: string;
-    cloneNode(deep?: boolean): HTMLParamElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLParamElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLParamElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8109,7 +8051,6 @@ declare var HTMLParamElement: {
 
 /** A <picture> HTML element. It doesn't implement specific properties or methods. */
 interface HTMLPictureElement extends HTMLElement {
-    cloneNode(deep?: boolean): HTMLPictureElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLPictureElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLPictureElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8128,7 +8069,6 @@ interface HTMLPreElement extends HTMLElement {
      */
     /** @deprecated */
     width: number;
-    cloneNode(deep?: boolean): HTMLPreElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLPreElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLPreElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8155,7 +8095,6 @@ interface HTMLProgressElement extends HTMLElement {
      * Sets or gets the current value of a progress element. The value must be a non-negative number between 0 and the max value.
      */
     value: number;
-    cloneNode(deep?: boolean): HTMLProgressElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLProgressElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLProgressElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8173,7 +8112,6 @@ interface HTMLQuoteElement extends HTMLElement {
      * Sets or retrieves reference information about the object.
      */
     cite: string;
-    cloneNode(deep?: boolean): HTMLQuoteElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLQuoteElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLQuoteElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8223,7 +8161,6 @@ interface HTMLScriptElement extends HTMLElement {
      * Sets or retrieves the MIME type for the associated scripting engine.
      */
     type: string;
-    cloneNode(deep?: boolean): HTMLScriptElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLScriptElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLScriptElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8300,7 +8237,6 @@ interface HTMLSelectElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLSelectElement;
     /**
      * Retrieves a select object or an object from an options collection.
      * @param name Variant of type Number or String that specifies the object or collection to retrieve. If this parameter is an integer, it is the zero-based index of the object. If this parameter is a string, all objects with matching name or id properties are retrieved, and a collection is returned if more than one match is made.
@@ -8340,7 +8276,6 @@ interface HTMLSlotElement extends HTMLElement {
     name: string;
     assignedElements(options?: AssignedNodesOptions): Element[];
     assignedNodes(options?: AssignedNodesOptions): Node[];
-    cloneNode(deep?: boolean): HTMLSlotElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSlotElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSlotElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8368,7 +8303,6 @@ interface HTMLSourceElement extends HTMLElement {
      * Gets or sets the MIME type of a media resource.
      */
     type: string;
-    cloneNode(deep?: boolean): HTMLSourceElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSourceElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSourceElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8382,7 +8316,6 @@ declare var HTMLSourceElement: {
 
 /** A <span> element and derives from the HTMLElement interface, but without implementing any additional properties or methods. */
 interface HTMLSpanElement extends HTMLElement {
-    cloneNode(deep?: boolean): HTMLSpanElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSpanElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLSpanElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8405,7 +8338,6 @@ interface HTMLStyleElement extends HTMLElement, LinkStyle {
      */
     /** @deprecated */
     type: string;
-    cloneNode(deep?: boolean): HTMLStyleElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLStyleElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLStyleElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8424,7 +8356,6 @@ interface HTMLTableCaptionElement extends HTMLElement {
      */
     /** @deprecated */
     align: string;
-    cloneNode(deep?: boolean): HTMLTableCaptionElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableCaptionElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableCaptionElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8495,7 +8426,6 @@ interface HTMLTableCellElement extends HTMLElement {
      */
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLTableCellElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8529,7 +8459,6 @@ interface HTMLTableColElement extends HTMLElement {
      */
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLTableColElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableColElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableColElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8542,7 +8471,6 @@ declare var HTMLTableColElement: {
 };
 
 interface HTMLTableDataCellElement extends HTMLTableCellElement {
-    cloneNode(deep?: boolean): HTMLTableDataCellElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableDataCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableDataCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8618,7 +8546,6 @@ interface HTMLTableElement extends HTMLElement {
      */
     /** @deprecated */
     width: string;
-    cloneNode(deep?: boolean): HTMLTableElement;
     /**
      * Creates an empty caption element in the table.
      */
@@ -8670,7 +8597,6 @@ declare var HTMLTableElement: {
 
 interface HTMLTableHeaderCellElement extends HTMLTableCellElement {
     scope: string;
-    cloneNode(deep?: boolean): HTMLTableHeaderCellElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableHeaderCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTableHeaderCellElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8709,7 +8635,6 @@ interface HTMLTableRowElement extends HTMLElement {
     readonly sectionRowIndex: number;
     /** @deprecated */
     vAlign: string;
-    cloneNode(deep?: boolean): HTMLTableRowElement;
     /**
      * Removes the specified cell from the table row, as well as from the cells collection.
      * @param index Number that specifies the zero-based position of the cell to remove from the table row. If no value is provided, the last cell in the cells collection is deleted.
@@ -8748,7 +8673,6 @@ interface HTMLTableSectionElement extends HTMLElement {
     readonly rows: HTMLCollectionOf<HTMLTableRowElement>;
     /** @deprecated */
     vAlign: string;
-    cloneNode(deep?: boolean): HTMLTableSectionElement;
     /**
      * Removes the specified row (tr) from the element and from the rows collection.
      * @param index Number that specifies the zero-based position in the rows collection of the row to remove.
@@ -8773,7 +8697,6 @@ declare var HTMLTableSectionElement: {
 /** Enables access to the contents of an HTML <template> element. */
 interface HTMLTemplateElement extends HTMLElement {
     readonly content: DocumentFragment;
-    cloneNode(deep?: boolean): HTMLTemplateElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTemplateElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTemplateElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8866,7 +8789,6 @@ interface HTMLTextAreaElement extends HTMLElement {
      * Returns whether a form will validate when it is submitted, without having to submit it.
      */
     checkValidity(): boolean;
-    cloneNode(deep?: boolean): HTMLTextAreaElement;
     reportValidity(): boolean;
     /**
      * Highlights the input area of a form element.
@@ -8900,7 +8822,6 @@ declare var HTMLTextAreaElement: {
 /** Provides special properties (beyond the regular HTMLElement interface it also has available to it by inheritance) for manipulating <time> elements. */
 interface HTMLTimeElement extends HTMLElement {
     dateTime: string;
-    cloneNode(deep?: boolean): HTMLTimeElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTimeElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTimeElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8918,7 +8839,6 @@ interface HTMLTitleElement extends HTMLElement {
      * Retrieves or sets the text of the object as a string.
      */
     text: string;
-    cloneNode(deep?: boolean): HTMLTitleElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTitleElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLTitleElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8939,7 +8859,6 @@ interface HTMLTrackElement extends HTMLElement {
     src: string;
     srclang: string;
     readonly track: TextTrack;
-    cloneNode(deep?: boolean): HTMLTrackElement;
     readonly ERROR: number;
     readonly LOADED: number;
     readonly LOADING: number;
@@ -8965,7 +8884,6 @@ interface HTMLUListElement extends HTMLElement {
     compact: boolean;
     /** @deprecated */
     type: string;
-    cloneNode(deep?: boolean): HTMLUListElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLUListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLUListElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -8979,7 +8897,6 @@ declare var HTMLUListElement: {
 
 /** An invalid HTML element and derives from the HTMLElement interface, but without implementing any additional properties or methods. */
 interface HTMLUnknownElement extends HTMLElement {
-    cloneNode(deep?: boolean): HTMLUnknownElement;
     addEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLUnknownElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof HTMLElementEventMap>(type: K, listener: (this: HTMLUnknownElement, ev: HTMLElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -9013,7 +8930,6 @@ interface HTMLVideoElement extends HTMLMediaElement {
      * Gets or sets the width of the video element.
      */
     width: number;
-    cloneNode(deep?: boolean): HTMLVideoElement;
     getVideoPlaybackQuality(): VideoPlaybackQuality;
     addEventListener<K extends keyof HTMLMediaElementEventMap>(type: K, listener: (this: HTMLVideoElement, ev: HTMLMediaElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -11858,7 +11774,6 @@ interface PositionError {
 interface ProcessingInstruction extends CharacterData, LinkStyle {
     readonly ownerDocument: Document;
     readonly target: string;
-    cloneNode(deep?: boolean): ProcessingInstruction;
 }
 
 declare var ProcessingInstruction: {
@@ -12694,7 +12609,6 @@ declare var Response: {
 /** Provides access to the properties of <a> element, as well as methods to manipulate them. */
 interface SVGAElement extends SVGGraphicsElement, SVGURIReference {
     readonly target: SVGAnimatedString;
-    cloneNode(deep?: boolean): SVGAElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12732,7 +12646,6 @@ declare var SVGAngle: {
 };
 
 interface SVGAnimateElement extends SVGAnimationElement {
-    cloneNode(deep?: boolean): SVGAnimateElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12745,7 +12658,6 @@ declare var SVGAnimateElement: {
 };
 
 interface SVGAnimateMotionElement extends SVGAnimationElement {
-    cloneNode(deep?: boolean): SVGAnimateMotionElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateMotionElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateMotionElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12758,7 +12670,6 @@ declare var SVGAnimateMotionElement: {
 };
 
 interface SVGAnimateTransformElement extends SVGAnimationElement {
-    cloneNode(deep?: boolean): SVGAnimateTransformElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateTransformElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGAnimateTransformElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12909,7 +12820,6 @@ declare var SVGAnimatedTransformList: {
 
 interface SVGAnimationElement extends SVGElement {
     readonly targetElement: SVGElement;
-    cloneNode(deep?: boolean): SVGAnimationElement;
     getCurrentTime(): number;
     getSimpleDuration(): number;
     getStartTime(): number;
@@ -12929,7 +12839,6 @@ interface SVGCircleElement extends SVGGeometryElement {
     readonly cx: SVGAnimatedLength;
     readonly cy: SVGAnimatedLength;
     readonly r: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGCircleElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGCircleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGCircleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12945,7 +12854,6 @@ declare var SVGCircleElement: {
 interface SVGClipPathElement extends SVGElement {
     readonly clipPathUnits: SVGAnimatedEnumeration;
     readonly transform: SVGAnimatedTransformList;
-    cloneNode(deep?: boolean): SVGClipPathElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGClipPathElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGClipPathElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -12966,7 +12874,6 @@ interface SVGComponentTransferFunctionElement extends SVGElement {
     readonly slope: SVGAnimatedNumber;
     readonly tableValues: SVGAnimatedNumberList;
     readonly type: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGComponentTransferFunctionElement;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_DISCRETE: number;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_GAMMA: number;
     readonly SVG_FECOMPONENTTRANSFER_TYPE_IDENTITY: number;
@@ -12993,7 +12900,6 @@ declare var SVGComponentTransferFunctionElement: {
 interface SVGCursorElement extends SVGElement {
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGCursorElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGCursorElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGCursorElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13007,7 +12913,6 @@ declare var SVGCursorElement: {
 
 /** Corresponds to the <defs> element. */
 interface SVGDefsElement extends SVGGraphicsElement {
-    cloneNode(deep?: boolean): SVGDefsElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGDefsElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGDefsElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13021,7 +12926,6 @@ declare var SVGDefsElement: {
 
 /** Corresponds to the <desc> element. */
 interface SVGDescElement extends SVGElement {
-    cloneNode(deep?: boolean): SVGDescElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGDescElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGDescElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13042,7 +12946,6 @@ interface SVGElement extends Element, DocumentAndElementEventHandlers, DocumentA
     readonly className: any;
     readonly ownerSVGElement: SVGSVGElement | null;
     readonly viewportElement: SVGElement | null;
-    cloneNode(deep?: boolean): SVGElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13082,7 +12985,6 @@ interface SVGEllipseElement extends SVGGeometryElement {
     readonly cy: SVGAnimatedLength;
     readonly rx: SVGAnimatedLength;
     readonly ry: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGEllipseElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGEllipseElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGEllipseElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13099,7 +13001,6 @@ interface SVGFEBlendElement extends SVGElement, SVGFilterPrimitiveStandardAttrib
     readonly in1: SVGAnimatedString;
     readonly in2: SVGAnimatedString;
     readonly mode: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGFEBlendElement;
     readonly SVG_FEBLEND_MODE_COLOR: number;
     readonly SVG_FEBLEND_MODE_COLOR_BURN: number;
     readonly SVG_FEBLEND_MODE_COLOR_DODGE: number;
@@ -13150,7 +13051,6 @@ interface SVGFEColorMatrixElement extends SVGElement, SVGFilterPrimitiveStandard
     readonly in1: SVGAnimatedString;
     readonly type: SVGAnimatedEnumeration;
     readonly values: SVGAnimatedNumberList;
-    cloneNode(deep?: boolean): SVGFEColorMatrixElement;
     readonly SVG_FECOLORMATRIX_TYPE_HUEROTATE: number;
     readonly SVG_FECOLORMATRIX_TYPE_LUMINANCETOALPHA: number;
     readonly SVG_FECOLORMATRIX_TYPE_MATRIX: number;
@@ -13175,7 +13075,6 @@ declare var SVGFEColorMatrixElement: {
 /** Corresponds to the <feComponentTransfer> element. */
 interface SVGFEComponentTransferElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
     readonly in1: SVGAnimatedString;
-    cloneNode(deep?: boolean): SVGFEComponentTransferElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEComponentTransferElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEComponentTransferElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13196,7 +13095,6 @@ interface SVGFECompositeElement extends SVGElement, SVGFilterPrimitiveStandardAt
     readonly k3: SVGAnimatedNumber;
     readonly k4: SVGAnimatedNumber;
     readonly operator: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGFECompositeElement;
     readonly SVG_FECOMPOSITE_OPERATOR_ARITHMETIC: number;
     readonly SVG_FECOMPOSITE_OPERATOR_ATOP: number;
     readonly SVG_FECOMPOSITE_OPERATOR_IN: number;
@@ -13236,7 +13134,6 @@ interface SVGFEConvolveMatrixElement extends SVGElement, SVGFilterPrimitiveStand
     readonly preserveAlpha: SVGAnimatedBoolean;
     readonly targetX: SVGAnimatedInteger;
     readonly targetY: SVGAnimatedInteger;
-    cloneNode(deep?: boolean): SVGFEConvolveMatrixElement;
     readonly SVG_EDGEMODE_DUPLICATE: number;
     readonly SVG_EDGEMODE_NONE: number;
     readonly SVG_EDGEMODE_UNKNOWN: number;
@@ -13263,7 +13160,6 @@ interface SVGFEDiffuseLightingElement extends SVGElement, SVGFilterPrimitiveStan
     readonly kernelUnitLengthX: SVGAnimatedNumber;
     readonly kernelUnitLengthY: SVGAnimatedNumber;
     readonly surfaceScale: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEDiffuseLightingElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDiffuseLightingElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDiffuseLightingElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13282,7 +13178,6 @@ interface SVGFEDisplacementMapElement extends SVGElement, SVGFilterPrimitiveStan
     readonly scale: SVGAnimatedNumber;
     readonly xChannelSelector: SVGAnimatedEnumeration;
     readonly yChannelSelector: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGFEDisplacementMapElement;
     readonly SVG_CHANNEL_A: number;
     readonly SVG_CHANNEL_B: number;
     readonly SVG_CHANNEL_G: number;
@@ -13308,7 +13203,6 @@ declare var SVGFEDisplacementMapElement: {
 interface SVGFEDistantLightElement extends SVGElement {
     readonly azimuth: SVGAnimatedNumber;
     readonly elevation: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEDistantLightElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDistantLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDistantLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13326,7 +13220,6 @@ interface SVGFEDropShadowElement extends SVGElement, SVGFilterPrimitiveStandardA
     readonly in1: SVGAnimatedString;
     readonly stdDeviationX: SVGAnimatedNumber;
     readonly stdDeviationY: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEDropShadowElement;
     setStdDeviation(stdDeviationX: number, stdDeviationY: number): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEDropShadowElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -13341,7 +13234,6 @@ declare var SVGFEDropShadowElement: {
 
 /** Corresponds to the <feFlood> element. */
 interface SVGFEFloodElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-    cloneNode(deep?: boolean): SVGFEFloodElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFloodElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFloodElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13355,7 +13247,6 @@ declare var SVGFEFloodElement: {
 
 /** Corresponds to the <feFuncA> element. */
 interface SVGFEFuncAElement extends SVGComponentTransferFunctionElement {
-    cloneNode(deep?: boolean): SVGFEFuncAElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncAElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncAElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13369,7 +13260,6 @@ declare var SVGFEFuncAElement: {
 
 /** Corresponds to the <feFuncB> element. */
 interface SVGFEFuncBElement extends SVGComponentTransferFunctionElement {
-    cloneNode(deep?: boolean): SVGFEFuncBElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncBElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncBElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13383,7 +13273,6 @@ declare var SVGFEFuncBElement: {
 
 /** Corresponds to the <feFuncG> element. */
 interface SVGFEFuncGElement extends SVGComponentTransferFunctionElement {
-    cloneNode(deep?: boolean): SVGFEFuncGElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13397,7 +13286,6 @@ declare var SVGFEFuncGElement: {
 
 /** Corresponds to the <feFuncR> element. */
 interface SVGFEFuncRElement extends SVGComponentTransferFunctionElement {
-    cloneNode(deep?: boolean): SVGFEFuncRElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncRElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEFuncRElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13414,7 +13302,6 @@ interface SVGFEGaussianBlurElement extends SVGElement, SVGFilterPrimitiveStandar
     readonly in1: SVGAnimatedString;
     readonly stdDeviationX: SVGAnimatedNumber;
     readonly stdDeviationY: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEGaussianBlurElement;
     setStdDeviation(stdDeviationX: number, stdDeviationY: number): void;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEGaussianBlurElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
@@ -13430,7 +13317,6 @@ declare var SVGFEGaussianBlurElement: {
 /** Corresponds to the <feImage> element. */
 interface SVGFEImageElement extends SVGElement, SVGFilterPrimitiveStandardAttributes, SVGURIReference {
     readonly preserveAspectRatio: SVGAnimatedPreserveAspectRatio;
-    cloneNode(deep?: boolean): SVGFEImageElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEImageElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEImageElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13444,7 +13330,6 @@ declare var SVGFEImageElement: {
 
 /** Corresponds to the <feMerge> element. */
 interface SVGFEMergeElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
-    cloneNode(deep?: boolean): SVGFEMergeElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEMergeElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEMergeElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13459,7 +13344,6 @@ declare var SVGFEMergeElement: {
 /** Corresponds to the <feMergeNode> element. */
 interface SVGFEMergeNodeElement extends SVGElement {
     readonly in1: SVGAnimatedString;
-    cloneNode(deep?: boolean): SVGFEMergeNodeElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEMergeNodeElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEMergeNodeElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13477,7 +13361,6 @@ interface SVGFEMorphologyElement extends SVGElement, SVGFilterPrimitiveStandardA
     readonly operator: SVGAnimatedEnumeration;
     readonly radiusX: SVGAnimatedNumber;
     readonly radiusY: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEMorphologyElement;
     readonly SVG_MORPHOLOGY_OPERATOR_DILATE: number;
     readonly SVG_MORPHOLOGY_OPERATOR_ERODE: number;
     readonly SVG_MORPHOLOGY_OPERATOR_UNKNOWN: number;
@@ -13500,7 +13383,6 @@ interface SVGFEOffsetElement extends SVGElement, SVGFilterPrimitiveStandardAttri
     readonly dx: SVGAnimatedNumber;
     readonly dy: SVGAnimatedNumber;
     readonly in1: SVGAnimatedString;
-    cloneNode(deep?: boolean): SVGFEOffsetElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEOffsetElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEOffsetElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13517,7 +13399,6 @@ interface SVGFEPointLightElement extends SVGElement {
     readonly x: SVGAnimatedNumber;
     readonly y: SVGAnimatedNumber;
     readonly z: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFEPointLightElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEPointLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFEPointLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13537,7 +13418,6 @@ interface SVGFESpecularLightingElement extends SVGElement, SVGFilterPrimitiveSta
     readonly specularConstant: SVGAnimatedNumber;
     readonly specularExponent: SVGAnimatedNumber;
     readonly surfaceScale: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFESpecularLightingElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFESpecularLightingElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFESpecularLightingElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13559,7 +13439,6 @@ interface SVGFESpotLightElement extends SVGElement {
     readonly x: SVGAnimatedNumber;
     readonly y: SVGAnimatedNumber;
     readonly z: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGFESpotLightElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFESpotLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFESpotLightElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13574,7 +13453,6 @@ declare var SVGFESpotLightElement: {
 /** Corresponds to the <feTile> element. */
 interface SVGFETileElement extends SVGElement, SVGFilterPrimitiveStandardAttributes {
     readonly in1: SVGAnimatedString;
-    cloneNode(deep?: boolean): SVGFETileElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFETileElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFETileElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13594,7 +13472,6 @@ interface SVGFETurbulenceElement extends SVGElement, SVGFilterPrimitiveStandardA
     readonly seed: SVGAnimatedNumber;
     readonly stitchTiles: SVGAnimatedEnumeration;
     readonly type: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGFETurbulenceElement;
     readonly SVG_STITCHTYPE_NOSTITCH: number;
     readonly SVG_STITCHTYPE_STITCH: number;
     readonly SVG_STITCHTYPE_UNKNOWN: number;
@@ -13626,7 +13503,6 @@ interface SVGFilterElement extends SVGElement, SVGURIReference {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGFilterElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFilterElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGFilterElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13657,7 +13533,6 @@ interface SVGForeignObjectElement extends SVGGraphicsElement {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGForeignObjectElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGForeignObjectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGForeignObjectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13671,7 +13546,6 @@ declare var SVGForeignObjectElement: {
 
 /** Corresponds to the <g> element. */
 interface SVGGElement extends SVGGraphicsElement {
-    cloneNode(deep?: boolean): SVGGElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGGElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13685,7 +13559,6 @@ declare var SVGGElement: {
 
 interface SVGGeometryElement extends SVGGraphicsElement {
     readonly pathLength: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGGeometryElement;
     getPointAtLength(distance: number): DOMPoint;
     getTotalLength(): number;
     isPointInFill(point?: DOMPointInit): boolean;
@@ -13706,7 +13579,6 @@ interface SVGGradientElement extends SVGElement, SVGURIReference {
     readonly gradientTransform: SVGAnimatedTransformList;
     readonly gradientUnits: SVGAnimatedEnumeration;
     readonly spreadMethod: SVGAnimatedEnumeration;
-    cloneNode(deep?: boolean): SVGGradientElement;
     readonly SVG_SPREADMETHOD_PAD: number;
     readonly SVG_SPREADMETHOD_REFLECT: number;
     readonly SVG_SPREADMETHOD_REPEAT: number;
@@ -13729,7 +13601,6 @@ declare var SVGGradientElement: {
 /** SVG elements whose primary purpose is to directly render graphics into a group. */
 interface SVGGraphicsElement extends SVGElement, SVGTests {
     readonly transform: SVGAnimatedTransformList;
-    cloneNode(deep?: boolean): SVGGraphicsElement;
     getBBox(options?: SVGBoundingBoxOptions): DOMRect;
     getCTM(): DOMMatrix | null;
     getScreenCTM(): DOMMatrix | null;
@@ -13751,7 +13622,6 @@ interface SVGImageElement extends SVGGraphicsElement, SVGURIReference {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGImageElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGImageElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGImageElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13825,7 +13695,6 @@ interface SVGLineElement extends SVGGeometryElement {
     readonly x2: SVGAnimatedLength;
     readonly y1: SVGAnimatedLength;
     readonly y2: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGLineElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGLineElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGLineElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13843,7 +13712,6 @@ interface SVGLinearGradientElement extends SVGGradientElement {
     readonly x2: SVGAnimatedLength;
     readonly y1: SVGAnimatedLength;
     readonly y2: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGLinearGradientElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGLinearGradientElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGLinearGradientElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13863,7 +13731,6 @@ interface SVGMarkerElement extends SVGElement, SVGFitToViewBox {
     readonly orientType: SVGAnimatedEnumeration;
     readonly refX: SVGAnimatedLength;
     readonly refY: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGMarkerElement;
     setOrientToAngle(angle: SVGAngle): void;
     setOrientToAuto(): void;
     readonly SVG_MARKERUNITS_STROKEWIDTH: number;
@@ -13897,7 +13764,6 @@ interface SVGMaskElement extends SVGElement {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGMaskElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGMaskElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGMaskElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13911,7 +13777,6 @@ declare var SVGMaskElement: {
 
 /** Corresponds to the <metadata> element. */
 interface SVGMetadataElement extends SVGElement {
-    cloneNode(deep?: boolean): SVGMetadataElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGMetadataElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGMetadataElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -13956,7 +13821,6 @@ declare var SVGNumberList: {
 interface SVGPathElement extends SVGGraphicsElement {
     /** @deprecated */
     readonly pathSegList: SVGPathSegList;
-    cloneNode(deep?: boolean): SVGPathElement;
     /** @deprecated */
     createSVGPathSegArcAbs(x: number, y: number, r1: number, r2: number, angle: number, largeArcFlag: boolean, sweepFlag: boolean): SVGPathSegArcAbs;
     /** @deprecated */
@@ -14295,7 +14159,6 @@ interface SVGPatternElement extends SVGElement, SVGFitToViewBox, SVGURIReference
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGPatternElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPatternElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPatternElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14327,7 +14190,6 @@ declare var SVGPointList: {
 
 /** Provides access to the properties of <polygon> elements, as well as methods to manipulate them. */
 interface SVGPolygonElement extends SVGGeometryElement, SVGAnimatedPoints {
-    cloneNode(deep?: boolean): SVGPolygonElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPolygonElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPolygonElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14341,7 +14203,6 @@ declare var SVGPolygonElement: {
 
 /** Provides access to the properties of <polyline> elements, as well as methods to manipulate them. */
 interface SVGPolylineElement extends SVGGeometryElement, SVGAnimatedPoints {
-    cloneNode(deep?: boolean): SVGPolylineElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPolylineElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGPolylineElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14400,7 +14261,6 @@ interface SVGRadialGradientElement extends SVGGradientElement {
     readonly fx: SVGAnimatedLength;
     readonly fy: SVGAnimatedLength;
     readonly r: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGRadialGradientElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGRadialGradientElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGRadialGradientElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14420,7 +14280,6 @@ interface SVGRectElement extends SVGGeometryElement {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGRectElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGRectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGRectElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14464,7 +14323,6 @@ interface SVGSVGElement extends SVGGraphicsElement, DocumentEvent, SVGFitToViewB
     animationsPaused(): boolean;
     checkEnclosure(element: SVGElement, rect: SVGRect): boolean;
     checkIntersection(element: SVGElement, rect: SVGRect): boolean;
-    cloneNode(deep?: boolean): SVGSVGElement;
     createSVGAngle(): SVGAngle;
     createSVGLength(): SVGLength;
     createSVGMatrix(): SVGMatrix;
@@ -14507,7 +14365,6 @@ declare var SVGSVGElement: {
 /** Corresponds to the SVG <script> element. */
 interface SVGScriptElement extends SVGElement, SVGURIReference {
     type: string;
-    cloneNode(deep?: boolean): SVGScriptElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGScriptElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGScriptElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14522,7 +14379,6 @@ declare var SVGScriptElement: {
 /** Corresponds to the <stop> element. */
 interface SVGStopElement extends SVGElement {
     readonly offset: SVGAnimatedNumber;
-    cloneNode(deep?: boolean): SVGStopElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGStopElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGStopElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14559,7 +14415,6 @@ interface SVGStyleElement extends SVGElement {
     media: string;
     title: string;
     type: string;
-    cloneNode(deep?: boolean): SVGStyleElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGStyleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGStyleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14573,7 +14428,6 @@ declare var SVGStyleElement: {
 
 /** Corresponds to the <switch> element. */
 interface SVGSwitchElement extends SVGGraphicsElement {
-    cloneNode(deep?: boolean): SVGSwitchElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSwitchElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSwitchElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14587,7 +14441,6 @@ declare var SVGSwitchElement: {
 
 /** Corresponds to the <symbol> element. */
 interface SVGSymbolElement extends SVGElement, SVGFitToViewBox {
-    cloneNode(deep?: boolean): SVGSymbolElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSymbolElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGSymbolElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14601,7 +14454,6 @@ declare var SVGSymbolElement: {
 
 /** A <tspan> element. */
 interface SVGTSpanElement extends SVGTextPositioningElement {
-    cloneNode(deep?: boolean): SVGTSpanElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTSpanElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTSpanElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14622,7 +14474,6 @@ interface SVGTests {
 interface SVGTextContentElement extends SVGGraphicsElement {
     readonly lengthAdjust: SVGAnimatedEnumeration;
     readonly textLength: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGTextContentElement;
     getCharNumAtPosition(point?: DOMPointInit): number;
     getComputedTextLength(): number;
     getEndPositionOfChar(charnum: number): DOMPoint;
@@ -14651,7 +14502,6 @@ declare var SVGTextContentElement: {
 
 /** Corresponds to the <text> elements. */
 interface SVGTextElement extends SVGTextPositioningElement {
-    cloneNode(deep?: boolean): SVGTextElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTextElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTextElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14668,7 +14518,6 @@ interface SVGTextPathElement extends SVGTextContentElement, SVGURIReference {
     readonly method: SVGAnimatedEnumeration;
     readonly spacing: SVGAnimatedEnumeration;
     readonly startOffset: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGTextPathElement;
     readonly TEXTPATH_METHODTYPE_ALIGN: number;
     readonly TEXTPATH_METHODTYPE_STRETCH: number;
     readonly TEXTPATH_METHODTYPE_UNKNOWN: number;
@@ -14699,7 +14548,6 @@ interface SVGTextPositioningElement extends SVGTextContentElement {
     readonly rotate: SVGAnimatedNumberList;
     readonly x: SVGAnimatedLengthList;
     readonly y: SVGAnimatedLengthList;
-    cloneNode(deep?: boolean): SVGTextPositioningElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTextPositioningElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTextPositioningElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14713,7 +14561,6 @@ declare var SVGTextPositioningElement: {
 
 /** Corresponds to the <title> element. */
 interface SVGTitleElement extends SVGElement {
-    cloneNode(deep?: boolean): SVGTitleElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTitleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGTitleElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14803,7 +14650,6 @@ interface SVGUseElement extends SVGGraphicsElement, SVGURIReference {
     readonly width: SVGAnimatedLength;
     readonly x: SVGAnimatedLength;
     readonly y: SVGAnimatedLength;
-    cloneNode(deep?: boolean): SVGUseElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGUseElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGUseElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -14819,7 +14665,6 @@ declare var SVGUseElement: {
 interface SVGViewElement extends SVGElement, SVGFitToViewBox, SVGZoomAndPan {
     /** @deprecated */
     readonly viewTarget: SVGStringList;
-    cloneNode(deep?: boolean): SVGViewElement;
     addEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGViewElement, ev: SVGElementEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof SVGElementEventMap>(type: K, listener: (this: SVGViewElement, ev: SVGElementEventMap[K]) => any, options?: boolean | EventListenerOptions): void;
@@ -15093,7 +14938,6 @@ interface ShadowRoot extends DocumentFragment, DocumentOrShadowRoot, InnerHTML {
     /**
      * Throws a "NotSupportedError" DOMException if context object is a shadow root.
      */
-    cloneNode(deep?: boolean): never;
 }
 
 declare var ShadowRoot: {
@@ -15565,7 +15409,6 @@ interface Text extends CharacterData, Slotable {
      * Returns the combined data of all direct Text node siblings.
      */
     readonly wholeText: string;
-    cloneNode(deep?: boolean): Text;
     /**
      * Splits data at the given offset and returns the remainder as Text node.
      */
@@ -18795,7 +18638,6 @@ interface WritableStreamDefaultWriter<W = any> {
 
 /** An XML document. It inherits from the generic Document and does not add any specific methods or properties to it: nevertheless, several algorithms behave differently with the two types of documents. */
 interface XMLDocument extends Document {
-    cloneNode(deep?: boolean): XMLDocument;
     addEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: XMLDocument, ev: DocumentEventMap[K]) => any, options?: boolean | AddEventListenerOptions): void;
     addEventListener(type: string, listener: EventListenerOrEventListenerObject, options?: boolean | AddEventListenerOptions): void;
     removeEventListener<K extends keyof DocumentEventMap>(type: K, listener: (this: XMLDocument, ev: DocumentEventMap[K]) => any, options?: boolean | EventListenerOptions): void;

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -254,12 +254,6 @@
                             "override-signatures": [
                                 "animationsPaused(): boolean"
                             ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGSVGElement"
-                            ]
                         }
                     }
                 }
@@ -302,12 +296,6 @@
                             "name": "setStdDeviation",
                             "override-signatures": [
                                 "setStdDeviation(stdDeviationX: number, stdDeviationY: number): void"
-                            ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEDropShadowElement"
                             ]
                         }
                     }
@@ -396,17 +384,7 @@
                     {
                         "name": "img"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLImageElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLMediaElement": {
                 "events": {
@@ -416,16 +394,6 @@
                             "type": "MediaEncryptedEvent"
                         }
                     ]
-                },
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMediaElement"
-                            ]
-                        }
-                    }
                 }
             },
             "CSSStyleDeclaration": {
@@ -680,12 +648,6 @@
                             "override-signatures": [
                                 "insertAdjacentText(where: InsertPosition, text: string): void"
                             ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): Element"
-                            ]
                         }
                     }
                 },
@@ -718,12 +680,6 @@
                                 "createElementNS<K extends keyof SVGElementTagNameMap>(namespaceURI: \"http://www.w3.org/2000/svg\", qualifiedName: K): SVGElementTagNameMap[K]",
                                 "createElementNS(namespaceURI: \"http://www.w3.org/2000/svg\", qualifiedName: string): SVGElement",
                                 "createElementNS(namespaceURI: string | null, qualifiedName: string, options?: ElementCreationOptions): Element"
-                            ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): Document"
                             ]
                         }
                     }
@@ -791,17 +747,7 @@
                     {
                         "name": "iframe"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLIFrameElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTextAreaElement": {
                 "name": "HTMLTextAreaElement",
@@ -810,16 +756,6 @@
                         "minLength": {
                             "name": "minLength",
                             "override-type": "number"
-                        }
-                    }
-                },
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTextAreaElement"
-                            ]
                         }
                     }
                 }
@@ -1088,12 +1024,6 @@
                             "override-signatures": [
                                 "getElementById(elementId: string): HTMLElement | null"
                             ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): DocumentFragment"
-                            ]
                         }
                     }
                 },
@@ -1167,17 +1097,7 @@
                 "implements": [
                     "GlobalEventHandlers",
                     "DocumentAndElementEventHandlers"
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "Text": {
                 "name": "Text",
@@ -1187,16 +1107,6 @@
                             "name": "assignedSlot",
                             "read-only": 1,
                             "override-type": "HTMLSlotElement | null"
-                        }
-                    }
-                },
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): Text"
-                            ]
                         }
                     }
                 }
@@ -1253,187 +1163,77 @@
                     {
                         "name": "a"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLAnchorElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLAreaElement": {
                 "element": [
                     {
                         "name": "area"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLAreaElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLAudioElement": {
                 "element": [
                     {
                         "name": "audio"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLAudioElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLBaseElement": {
                 "element": [
                     {
                         "name": "base"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLBaseElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLBodyElement": {
                 "element": [
                     {
                         "name": "body"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLBodyElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLBRElement": {
                 "element": [
                     {
                         "name": "br"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLBRElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLCanvasElement": {
                 "element": [
                     {
                         "name": "canvas"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLCanvasElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLDataElement": {
                 "element": [
                     {
                         "name": "data"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDataElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLDetailsElement": {
                 "element": [
                     {
                         "name": "details"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDetailsElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLDivElement": {
                 "element": [
                     {
                         "name": "div"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDivElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLDListElement": {
                 "element": [
                     {
                         "name": "dl"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDListElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLElement": {
                 "element": [
@@ -1554,68 +1354,28 @@
                 ],
                 "implements": [
                     "ElementCSSInlineStyle"
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLEmbedElement": {
                 "element": [
                     {
                         "name": "embed"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLEmbedElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLFormElement": {
                 "element": [
                     {
                         "name": "form"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLFormElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLHeadElement": {
                 "element": [
                     {
                         "name": "head"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLHeadElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLHeadingElement": {
                 "element": [
@@ -1637,51 +1397,21 @@
                     {
                         "name": "h6"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLHeadingElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLHRElement": {
                 "element": [
                     {
                         "name": "hr"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLHRElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLHtmlElement": {
                 "element": [
                     {
                         "name": "html"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLHtmlElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLInputElement": {
                 "properties": {
@@ -1695,17 +1425,7 @@
                     {
                         "name": "input"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLInputElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLLinkElement": {
                 "properties": {
@@ -1720,102 +1440,42 @@
                     {
                         "name": "link"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLLinkElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLLabelElement": {
                 "element": [
                     {
                         "name": "label"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLLabelElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLLIElement": {
                 "element": [
                     {
                         "name": "li"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLLIElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLMapElement": {
                 "element": [
                     {
                         "name": "map"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMapElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLMenuElement": {
                 "element": [
                     {
                         "name": "menu"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMenuElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLMetaElement": {
                 "element": [
                     {
                         "name": "meta"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMetaElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLModElement": {
                 "element": [
@@ -1825,102 +1485,42 @@
                     {
                         "name": "ins"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLModElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLObjectElement": {
                 "element": [
                     {
                         "name": "object"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLObjectElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLOListElement": {
                 "element": [
                     {
                         "name": "ol"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLOListElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLParagraphElement": {
                 "element": [
                     {
                         "name": "p"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLParagraphElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLParamElement": {
                 "element": [
                     {
                         "name": "param"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLParamElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLPictureElement": {
                 "element": [
                     {
                         "name": "picture"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLPictureElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLPreElement": {
                 "element": [
@@ -1935,17 +1535,7 @@
                         "name": "xmp",
                         "deprecated": true
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLPreElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLQuoteElement": {
                 "element": [
@@ -1955,119 +1545,49 @@
                     {
                         "name": "q"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLQuoteElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLScriptElement": {
                 "element": [
                     {
                         "name": "script"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLScriptElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLSlotElement": {
                 "element": [
                     {
                         "name": "slot"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLSlotElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLSourceElement": {
                 "element": [
                     {
                         "name": "source"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLSourceElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLSpanElement": {
                 "element": [
                     {
                         "name": "span"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLSpanElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLStyleElement": {
                 "element": [
                     {
                         "name": "style"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLStyleElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableCaptionElement": {
                 "element": [
                     {
                         "name": "caption"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableCaptionElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableCellElement": {
                 "element": [
@@ -2077,17 +1597,7 @@
                     {
                         "name": "th"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableCellElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableColElement": {
                 "element": [
@@ -2097,17 +1607,7 @@
                     {
                         "name": "colgroup"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableColElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableDataCellElement": {
                 "name": "HTMLTableDataCellElement",
@@ -2119,34 +1619,14 @@
                         "namespace": "HTML",
                         "name": "td"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableDataCellElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableElement": {
                 "element": [
                     {
                         "name": "table"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableHeaderCellElement": {
                 "name": "HTMLTableHeaderCellElement",
@@ -2164,34 +1644,14 @@
                     {
                         "name": "th"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableHeaderCellElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableRowElement": {
                 "element": [
                     {
                         "name": "tr"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableRowElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTableSectionElement": {
                 "element": [
@@ -2204,136 +1664,56 @@
                     {
                         "name": "thead"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTableSectionElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTimeElement": {
                 "element": [
                     {
                         "name": "time"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTimeElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTitleElement": {
                 "element": [
                     {
                         "name": "title"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTitleElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTemplateElement": {
                 "element": [
                     {
                         "name": "template"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTemplateElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLTrackElement": {
                 "element": [
                     {
                         "name": "track"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLTrackElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLUListElement": {
                 "element": [
                     {
                         "name": "ul"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLUListElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLVideoElement": {
                 "element": [
                     {
                         "name": "video"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLVideoElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "HTMLDialogElement": {
                 "element": [
                     {
                         "name": "dialog"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDialogElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "EXT_blend_minmax": {
                 "override-exposed": "Window Worker"
@@ -2421,16 +1801,6 @@
                             "override-type": "SVGAnimatedLength"
                         }
                     }
-                },
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGCursorElement"
-                            ]
-                        }
-                    }
                 }
             },
             "SVGAnimationElement": {
@@ -2465,12 +1835,6 @@
                             "override-signatures": [
                                 "getSimpleDuration(): number"
                             ]
-                        },
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGAnimationElement"
-                            ]
                         }
                     }
                 }
@@ -2478,47 +1842,17 @@
             "SVGAnimateElement": {
                 "name": "SVGAnimateElement",
                 "extends": "SVGAnimationElement",
-                "exposed": "Window",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGAnimateElement"
-                            ]
-                        }
-                    }
-                }
+                "exposed": "Window"
             },
             "SVGAnimateTransformElement": {
                 "name": "SVGAnimateTransformElement",
                 "extends": "SVGAnimationElement",
-                "exposed": "Window",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGAnimateTransformElement"
-                            ]
-                        }
-                    }
-                }
+                "exposed": "Window"
             },
             "SVGAnimateMotionElement": {
                 "name": "SVGAnimateMotionElement",
                 "extends": "SVGAnimationElement",
-                "exposed": "Window",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGAnimateMotionElement"
-                            ]
-                        }
-                    }
-                }
+                "exposed": "Window"
             },
             "SVGRectElement": {
                 "element": [
@@ -2526,17 +1860,7 @@
                         "namespace": "SVG",
                         "name": "rect"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGRectElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGCircleElement": {
                 "element": [
@@ -2544,17 +1868,7 @@
                         "namespace": "SVG",
                         "name": "circle"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGCircleElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGClipPathElement": {
                 "element": [
@@ -2562,17 +1876,7 @@
                         "namespace": "SVG",
                         "name": "clipPath"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGClipPathElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGEllipseElement": {
                 "element": [
@@ -2580,17 +1884,7 @@
                         "namespace": "SVG",
                         "name": "ellipse"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGEllipseElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEBlendElement": {
                 "element": [
@@ -2598,17 +1892,7 @@
                         "namespace": "SVG",
                         "name": "feBlend"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEBlendElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEColorMatrixElement": {
                 "element": [
@@ -2616,17 +1900,7 @@
                         "namespace": "SVG",
                         "name": "feColorMatrix"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEColorMatrixElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEComponentTransferElement": {
                 "element": [
@@ -2634,17 +1908,7 @@
                         "namespace": "SVG",
                         "name": "feComponentTransfer"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEComponentTransferElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFECompositeElement": {
                 "element": [
@@ -2652,17 +1916,7 @@
                         "namespace": "SVG",
                         "name": "feComposite"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFECompositeElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEConvolveMatrixElement": {
                 "element": [
@@ -2670,17 +1924,7 @@
                         "namespace": "SVG",
                         "name": "feConvolveMatrix"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEConvolveMatrixElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEDiffuseLightingElement": {
                 "element": [
@@ -2688,17 +1932,7 @@
                         "namespace": "SVG",
                         "name": "feDiffuseLighting"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEDiffuseLightingElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEDisplacementMapElement": {
                 "element": [
@@ -2706,17 +1940,7 @@
                         "namespace": "SVG",
                         "name": "feDisplacementMap"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEDisplacementMapElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEDistantLightElement": {
                 "element": [
@@ -2724,17 +1948,7 @@
                         "namespace": "SVG",
                         "name": "feDistantLight"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEDistantLightElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEFloodElement": {
                 "element": [
@@ -2742,17 +1956,7 @@
                         "namespace": "SVG",
                         "name": "feFlood"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEFloodElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEFuncAElement": {
                 "element": [
@@ -2760,17 +1964,7 @@
                         "namespace": "SVG",
                         "name": "feFuncA"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEFuncAElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEFuncBElement": {
                 "element": [
@@ -2778,17 +1972,7 @@
                         "namespace": "SVG",
                         "name": "feFuncB"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEFuncBElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEFuncGElement": {
                 "element": [
@@ -2796,17 +1980,7 @@
                         "namespace": "SVG",
                         "name": "feFuncG"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEFuncGElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEFuncRElement": {
                 "element": [
@@ -2814,17 +1988,7 @@
                         "namespace": "SVG",
                         "name": "feFuncR"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEFuncRElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEGaussianBlurElement": {
                 "element": [
@@ -2832,17 +1996,7 @@
                         "namespace": "SVG",
                         "name": "feGaussianBlur"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEGaussianBlurElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEImageElement": {
                 "element": [
@@ -2850,17 +2004,7 @@
                         "namespace": "SVG",
                         "name": "feImage"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEImageElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEMergeElement": {
                 "element": [
@@ -2868,17 +2012,7 @@
                         "namespace": "SVG",
                         "name": "feMerge"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEMergeElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEMergeNodeElement": {
                 "element": [
@@ -2886,17 +2020,7 @@
                         "namespace": "SVG",
                         "name": "feMergeNode"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEMergeNodeElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEMorphologyElement": {
                 "element": [
@@ -2904,17 +2028,7 @@
                         "namespace": "SVG",
                         "name": "feMorphology"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEMorphologyElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEOffsetElement": {
                 "element": [
@@ -2922,17 +2036,7 @@
                         "namespace": "SVG",
                         "name": "feOffset"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEOffsetElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFEPointLightElement": {
                 "element": [
@@ -2940,17 +2044,7 @@
                         "namespace": "SVG",
                         "name": "fePointLight"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFEPointLightElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFESpecularLightingElement": {
                 "element": [
@@ -2958,17 +2052,7 @@
                         "namespace": "SVG",
                         "name": "feSpecularLighting"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFESpecularLightingElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFESpotLightElement": {
                 "element": [
@@ -2976,17 +2060,7 @@
                         "namespace": "SVG",
                         "name": "feSpotLight"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFESpotLightElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFETileElement": {
                 "element": [
@@ -2994,17 +2068,7 @@
                         "namespace": "SVG",
                         "name": "feTile"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFETileElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFETurbulenceElement": {
                 "element": [
@@ -3012,17 +2076,7 @@
                         "namespace": "SVG",
                         "name": "feTurbulence"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFETurbulenceElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGFilterElement": {
                 "element": [
@@ -3030,17 +2084,7 @@
                         "namespace": "SVG",
                         "name": "filter"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGFilterElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGLinearGradientElement": {
                 "element": [
@@ -3048,17 +2092,7 @@
                         "namespace": "SVG",
                         "name": "linearGradient"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGLinearGradientElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGLineElement": {
                 "element": [
@@ -3066,17 +2100,7 @@
                         "namespace": "SVG",
                         "name": "line"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGLineElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGMarkerElement": {
                 "element": [
@@ -3084,17 +2108,7 @@
                         "namespace": "SVG",
                         "name": "marker"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGMarkerElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGMaskElement": {
                 "element": [
@@ -3102,17 +2116,7 @@
                         "namespace": "SVG",
                         "name": "mask"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGMaskElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGPatternElement": {
                 "element": [
@@ -3120,17 +2124,7 @@
                         "namespace": "SVG",
                         "name": "pattern"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGPatternElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGPolygonElement": {
                 "element": [
@@ -3138,17 +2132,7 @@
                         "namespace": "SVG",
                         "name": "polygon"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGPolygonElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGPolylineElement": {
                 "element": [
@@ -3156,17 +2140,7 @@
                         "namespace": "SVG",
                         "name": "polyline"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGPolylineElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGRadialGradientElement": {
                 "element": [
@@ -3174,17 +2148,7 @@
                         "namespace": "SVG",
                         "name": "radialGradient"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGRadialGradientElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGStopElement": {
                 "element": [
@@ -3192,17 +2156,7 @@
                         "namespace": "SVG",
                         "name": "stop"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGStopElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGTextElement": {
                 "element": [
@@ -3210,17 +2164,7 @@
                         "namespace": "SVG",
                         "name": "text"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTextElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGTextPathElement": {
                 "element": [
@@ -3228,17 +2172,7 @@
                         "namespace": "SVG",
                         "name": "textPath"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTextPathElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "SVGTSpanElement": {
                 "element": [
@@ -3246,17 +2180,7 @@
                         "namespace": "SVG",
                         "name": "tspan"
                     }
-                ],
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTSpanElement"
-                            ]
-                        }
-                    }
-                }
+                ]
             },
             "MediaStream": {
                 "events": {
@@ -3348,647 +2272,48 @@
             },
             "Attr": {
                 "name": "Attr",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): Attr"
-                            ]
-                        }
-                    }
-                },
                 "properties": {
                     "property": {
                         "ownerDocument": {
                             "name": "ownerDocument",
                             "read-only": 1,
                             "override-type": "Document"
-                        }
-                    }
-                }
-            },
-            "CDATASection": {
-                "name": "CDATASection",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): CDATASection"
-                            ]
                         }
                     }
                 }
             },
             "CharacterData": {
                 "name": "CharacterData",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): CharacterData"
-                            ]
-                        }
-                    }
-                },
                 "properties": {
                     "property": {
                         "ownerDocument": {
                             "name": "ownerDocument",
                             "read-only": 1,
                             "override-type": "Document"
-                        }
-                    }
-                }
-            },
-            "Comment": {
-                "name": "Comment",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): Comment"
-                            ]
                         }
                     }
                 }
             },
             "DocumentType": {
                 "name": "DocumentType",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): DocumentType"
-                            ]
-                        }
-                    }
-                },
                 "properties": {
                     "property": {
                         "ownerDocument": {
                             "name": "ownerDocument",
                             "read-only": 1,
                             "override-type": "Document"
-                        }
-                    }
-                }
-            },
-            "HTMLAppletElement": {
-                "name": "HTMLAppletElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLAppletElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLBaseFontElement": {
-                "name": "HTMLBaseFontElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLBaseFontElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLButtonElement": {
-                "name": "HTMLButtonElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLButtonElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLDataListElement": {
-                "name": "HTMLDataListElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDataListElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLDirectoryElement": {
-                "name": "HTMLDirectoryElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDirectoryElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLDocument": {
-                "name": "HTMLDocument",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLDocument"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLFieldSetElement": {
-                "name": "HTMLFieldSetElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLFieldSetElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLFontElement": {
-                "name": "HTMLFontElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLFontElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLFrameElement": {
-                "name": "HTMLFrameElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLFrameElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLFrameSetElement": {
-                "name": "HTMLFrameSetElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLFrameSetElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLLegendElement": {
-                "name": "HTMLLegendElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLLegendElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLMarqueeElement": {
-                "name": "HTMLMarqueeElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMarqueeElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLMeterElement": {
-                "name": "HTMLMeterElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLMeterElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLOptGroupElement": {
-                "name": "HTMLOptGroupElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLOptGroupElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLOptionElement": {
-                "name": "HTMLOptionElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLOptionElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLOutputElement": {
-                "name": "HTMLOutputElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLOutputElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLProgressElement": {
-                "name": "HTMLProgressElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLProgressElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLSelectElement": {
-                "name": "HTMLSelectElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLSelectElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "HTMLUnknownElement": {
-                "name": "HTMLUnknownElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): HTMLUnknownElement"
-                            ]
                         }
                     }
                 }
             },
             "ProcessingInstruction": {
                 "name": "ProcessingInstruction",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): ProcessingInstruction"
-                            ]
-                        }
-                    }
-                },
                 "properties": {
                     "property": {
                         "ownerDocument": {
                             "name": "ownerDocument",
                             "read-only": 1,
                             "override-type": "Document"
-                        }
-                    }
-                }
-            },
-            "ShadowRoot": {
-                "name": "ShadowRoot",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): never"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGAElement": {
-                "name": "SVGAElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGAElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGComponentTransferFunctionElement": {
-                "name": "SVGComponentTransferFunctionElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGComponentTransferFunctionElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGDefsElement": {
-                "name": "SVGDefsElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGDefsElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGDescElement": {
-                "name": "SVGDescElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGDescElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGForeignObjectElement": {
-                "name": "SVGForeignObjectElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGForeignObjectElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGGElement": {
-                "name": "SVGGElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGGElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGGeometryElement": {
-                "name": "SVGGeometryElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGGeometryElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGGradientElement": {
-                "name": "SVGGradientElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGGradientElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGGraphicsElement": {
-                "name": "SVGGraphicsElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGGraphicsElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGImageElement": {
-                "name": "SVGImageElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGImageElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGMetadataElement": {
-                "name": "SVGMetadataElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGMetadataElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGPathElement": {
-                "name": "SVGPathElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGPathElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGScriptElement": {
-                "name": "SVGScriptElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGScriptElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGStyleElement": {
-                "name": "SVGStyleElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGStyleElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGSwitchElement": {
-                "name": "SVGSwitchElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGSwitchElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGSymbolElement": {
-                "name": "SVGSymbolElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGSymbolElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGTextContentElement": {
-                "name": "SVGTextContentElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTextContentElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGTextPositioningElement": {
-                "name": "SVGTextPositioningElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTextPositioningElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGTitleElement": {
-                "name": "SVGTitleElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGTitleElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGUseElement": {
-                "name": "SVGUseElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGUseElement"
-                            ]
-                        }
-                    }
-                }
-            },
-            "SVGViewElement": {
-                "name": "SVGViewElement",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): SVGViewElement"
-                            ]
                         }
                     }
                 }
@@ -4022,19 +2347,6 @@
                             "type": "PromiseRejectionEvent"
                         }
                     ]
-                }
-            },
-            "XMLDocument": {
-                "name": "XMLDocument",
-                "methods": {
-                    "method": {
-                        "cloneNode": {
-                            "name": "cloneNode",
-                            "override-signatures": [
-                                "cloneNode(deep?: boolean): XMLDocument"
-                            ]
-                        }
-                    }
                 }
             }
         }


### PR DESCRIPTION
They make `@types/tablesorter`, a jquery dependent, invariant in a complex way that I have yet to figure out. I'm reverting this change for 3.9 until I
have time to see how likely other projects are to encounter the problem.

@orta @DanielRosenwasser 