### PR TITLE
Refine webworker interface clients get signature

### DIFF
--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -893,7 +893,7 @@ declare var Client: {
 /** Provides access to Client objects. Access it via self.clients within a service worker. */
 interface Clients {
     claim(): Promise<void>;
-    get(id: string): Promise<any>;
+    get(id: string): Promise<Client | undefined>;
     matchAll(options?: ClientQueryOptions): Promise<ReadonlyArray<Client>>;
     openWindow(url: string): Promise<WindowClient | null>;
 }

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -2695,6 +2695,17 @@
                         }
                     }
                 }
+            },
+            "Clients": {
+                "methods": {
+                    "method": {
+                        "get": {
+                            "override-signatures": [
+                                "get(id: string): Promise<Client | undefined>"
+                            ]
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
fixes https://github.com/microsoft/TypeScript/issues/36705

it should be https://w3c.github.io/ServiceWorker/#dom-clients-get
`  get(id: string): Promise<Client | undefined>; `