### PR TITLE
ci: ensure master branch is also tested

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,5 @@
 name: CI
-on: pull_request
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Repo moved to GitHub Actions with https://github.com/microsoft/TSJS-lib-generator/pull/862.
But that's also when `master` stopped being tested.