### PR TITLE
Remove redundant override-signatures

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -3799,7 +3799,7 @@ declare var DOMException: {
 
 /** An object providing methods which are not dependent on any particular document. Such an object is returned by the Document.implementation property. */
 interface DOMImplementation {
-    createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document;
+    createDocument(namespace: string | null, qualifiedName: string | null, doctype?: DocumentType | null): XMLDocument;
     createDocumentType(qualifiedName: string, publicId: string, systemId: string): DocumentType;
     createHTMLDocument(title?: string): Document;
     /** @deprecated */
@@ -5148,8 +5148,8 @@ interface Element extends Node, Animatable, ChildNode, InnerHTML, NonDocumentTyp
      * Returns the qualified names of all element's attributes. Can contain duplicates.
      */
     getAttributeNames(): string[];
-    getAttributeNode(name: string): Attr | null;
-    getAttributeNodeNS(namespaceURI: string, localName: string): Attr | null;
+    getAttributeNode(qualifiedName: string): Attr | null;
+    getAttributeNodeNS(namespace: string | null, localName: string): Attr | null;
     getBoundingClientRect(): DOMRect;
     getClientRects(): DOMRectList;
     /**
@@ -9110,7 +9110,7 @@ interface IDBDatabase extends EventTarget {
      * 
      * Throws a "InvalidStateError" DOMException if not called within an upgrade transaction.
      */
-    createObjectStore(name: string, optionalParameters?: IDBObjectStoreParameters): IDBObjectStore;
+    createObjectStore(name: string, options?: IDBObjectStoreParameters): IDBObjectStore;
     /**
      * Deletes the object store with the given name.
      * 
@@ -9558,8 +9558,8 @@ interface ImageData {
 
 declare var ImageData: {
     prototype: ImageData;
-    new(width: number, height: number): ImageData;
-    new(array: Uint8ClampedArray, width: number, height?: number): ImageData;
+    new(sw: number, sh: number): ImageData;
+    new(data: Uint8ClampedArray, sw: number, sh?: number): ImageData;
 };
 
 interface InnerHTML {

--- a/baselines/dom.iterable.generated.d.ts
+++ b/baselines/dom.iterable.generated.d.ts
@@ -109,6 +109,13 @@ interface Headers {
     values(): IterableIterator<string>;
 }
 
+interface IDBDatabase {
+    /**
+     * Returns a new transaction with the given mode ("readonly" or "readwrite") and scope which can be a single object store name or an array of names.
+     */
+    transaction(storeNames: string | Iterable<string>, mode?: IDBTransactionMode): IDBTransaction;
+}
+
 interface IDBObjectStore {
     /**
      * Creates a new index in store with the given name, keyPath and options and returns a new IDBIndex. If the keyPath and options define constraints that cannot be satisfied with the data already in store the upgrade transaction will abort with a "ConstraintError" DOMException.

--- a/baselines/webworker.generated.d.ts
+++ b/baselines/webworker.generated.d.ts
@@ -1761,7 +1761,7 @@ interface IDBDatabase extends EventTarget {
      * 
      * Throws a "InvalidStateError" DOMException if not called within an upgrade transaction.
      */
-    createObjectStore(name: string, optionalParameters?: IDBObjectStoreParameters): IDBObjectStore;
+    createObjectStore(name: string, options?: IDBObjectStoreParameters): IDBObjectStore;
     /**
      * Deletes the object store with the given name.
      * 
@@ -2199,8 +2199,8 @@ interface ImageData {
 
 declare var ImageData: {
     prototype: ImageData;
-    new(width: number, height: number): ImageData;
-    new(array: Uint8ClampedArray, width: number, height?: number): ImageData;
+    new(sw: number, sh: number): ImageData;
+    new(data: Uint8ClampedArray, sw: number, sh?: number): ImageData;
 };
 
 /** This Channel Messaging API interface allows us to create a new message channel and send data through it via its two MessagePort properties. */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1,19 +1,6 @@
 {
     "mixins": {
         "mixin": {
-            "GlobalFetch": {
-                "name": "GlobalFetch",
-                "methods": {
-                    "method": {
-                        "fetch": {
-                            "name": "fetch",
-                            "override-signatures": [
-                                "fetch(input: RequestInfo, init?: RequestInit): Promise<Response>"
-                            ]
-                        }
-                    }
-                }
-            },
             "Animatable": {
                 "name": "Animatable",
                 "methods": {
@@ -225,12 +212,6 @@
             "OnErrorEventHandlerNonNull": {
                 "override-signatures": [
                     "(event: Event | string, source?: string, lineno?: number, colno?: number, error?: Error): any"
-                ]
-            },
-            "DecodeErrorCallback": {
-                "name": "DecodeErrorCallback",
-                "override-signatures": [
-                    "(error: DOMException): void"
                 ]
             },
             "QueuingStrategySizeCallback": {
@@ -531,12 +512,6 @@
                                 "getElementById(elementId: string): HTMLElement | null"
                             ]
                         },
-                        "elementsFromPoint": {
-                            "name": "elementsFromPoint",
-                            "override-signatures": [
-                                "elementsFromPoint(x: number, y: number): Element[]"
-                            ]
-                        },
                         "getElementsByTagNameNS": {
                             "name": "getElementsByTagNameNS",
                             "override-signatures": [
@@ -693,13 +668,6 @@
                 },
                 "properties": {
                     "property": {
-                        "isConnected": {
-                            "name": "isConnected",
-                            "default": "false",
-                            "read-only": 1,
-                            "type-original": "boolean",
-                            "type": "boolean"
-                        },
                         "parentNode": {
                             "override-type": "Node & ParentNode | null"
                         },
@@ -811,23 +779,6 @@
                     }
                 }
             },
-            "MediaError": {
-                "name": "MediaError",
-                "properties": {
-                    "property": {
-                        "message": {
-                            "specs": "html5",
-                            "name": "message",
-                            "tags": "Media",
-                            "type": "DOMString",
-                            "type-original": "DOMString",
-                            "read-only": 1,
-                            "exposed": "Window",
-                            "default": "\"\""
-                        }
-                    }
-                }
-            },
             "IDBIndex": {
                 "name": "IDBIndex",
                 "properties": {
@@ -881,33 +832,6 @@
                             "override-signatures": [
                                 "getKey(key: IDBValidKey | IDBKeyRange): IDBRequest<IDBValidKey | undefined>"
                             ]
-                        }
-                    }
-                }
-            },
-            "IDBDatabase": {
-                "name": "IDBDatabase",
-                "methods": {
-                    "method": {
-                        "createObjectStore": {
-                            "name": "createObjectStore",
-                            "override-signatures": [
-                                "createObjectStore(name: string, optionalParameters?: IDBObjectStoreParameters): IDBObjectStore"
-                            ]
-                        },
-                        "transaction": {
-                            "name": "transaction",
-                            "override-signatures": [
-                                "transaction(storeNames: string | string[], mode?: IDBTransactionMode): IDBTransaction"
-                            ]
-                        }
-                    }
-                },
-                "properties": {
-                    "property": {
-                        "version": {
-                            "name": "version",
-                            "override-type": "number"
                         }
                     }
                 }
@@ -1019,24 +943,6 @@
                     }
                 }
             },
-            "ImageData": {
-                "name": "ImageData",
-                "exposed": "Window Worker",
-                "constructor": {
-                    "override-signatures": [
-                        "new(width: number, height: number): ImageData",
-                        "new(array: Uint8ClampedArray, width: number, height?: number): ImageData"
-                    ]
-                }
-            },
-            "DOMException": {
-                "name": "DOMException",
-                "constructor": {
-                    "override-signatures": [
-                        "new(message?: string, name?: string): DOMException"
-                    ]
-                }
-            },
             "HTMLSelectElement": {
                 "name": "HTMLSelectElement",
                 "properties": {
@@ -1125,16 +1031,6 @@
             },
             "HTMLTableSectionElement": {
                 "name": "HTMLTableSectionElement",
-                "methods": {
-                    "method": {
-                        "insertRow": {
-                            "name": "insertRow",
-                            "override-signatures": [
-                                "insertRow(index?: number): HTMLTableRowElement"
-                            ]
-                        }
-                    }
-                },
                 "properties": {
                     "property": {
                         "rows": {
@@ -1148,18 +1044,6 @@
                 "name": "Element",
                 "methods": {
                     "method": {
-                        "getAttributeNodeNS": {
-                            "name": "getAttributeNodeNS",
-                            "override-signatures": [
-                                "getAttributeNodeNS(namespaceURI: string, localName: string): Attr | null"
-                            ]
-                        },
-                        "getAttributeNode": {
-                            "name": "getAttributeNode",
-                            "override-signatures": [
-                                "getAttributeNode(name: string): Attr | null"
-                            ]
-                        },
                         "getElementsByTagNameNS": {
                             "name": "getElementsByTagNameNS",
                             "override-signatures": [
@@ -1287,23 +1171,6 @@
                 }
             },
             "Storage": {
-                "name": "Storage",
-                "methods": {
-                    "method": {
-                        "getItem": {
-                            "name": "getItem",
-                            "override-signatures": [
-                                "getItem(key: string): string | null"
-                            ]
-                        },
-                        "key": {
-                            "name": "key",
-                            "override-signatures": [
-                                "key(index: number): string | null"
-                            ]
-                        }
-                    }
-                },
                 "override-index-signatures": [
                     "[name: string]: any"
                 ]
@@ -1401,16 +1268,6 @@
                 "name": "HTMLInputElement",
                 "properties": {
                     "property": {
-                        "files": {
-                            "name": "files",
-                            "read-only": 0,
-                            "override-type": "FileList | null"
-                        },
-                        "form": {
-                            "name": "form",
-                            "read-only": 1,
-                            "override-type": "HTMLFormElement | null"
-                        },
                         "selectionDirection": {
                             "name": "selectionDirection",
                             "override-type": "\"forward\" | \"backward\" | \"none\""
@@ -1461,12 +1318,6 @@
                                 "hasFeature(...args: any[]): true"
                             ],
                             "deprecated": 1
-                        },
-                        "createDocument": {
-                            "name": "createDocument",
-                            "override-signatures": [
-                                "createDocument(namespaceURI: string | null, qualifiedName: string | null, doctype: DocumentType | null): Document"
-                            ]
                         }
                     }
                 }

--- a/src/emitter.ts
+++ b/src/emitter.ts
@@ -699,9 +699,7 @@ export function emitWebIdl(webidl: Browser.WebIdl, flavor: Flavor) {
             method["override-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
         }
         else if (method.signature) {
-            if (method["additional-signatures"]) {
-                method["additional-signatures"]!.forEach(s => printLine(`${prefix}${s};`));
-            }
+            method["additional-signatures"]?.forEach(s => printLine(`${prefix}${s};`));
             method.signature.forEach(sig => emitSignature(sig, prefix, name, printLine));
         }
     }


### PR DESCRIPTION
The field tends to shadow upstream updates to the methods. This patch is the first step to reduce such uses.