### PR TITLE
Restrict possible values of DataTransfer.dropEffect and DataTransfer.effectAllowed.

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4167,7 +4167,7 @@ interface DataTransfer {
      * 
      * The possible values are "none", "copy", "link", and "move".
      */
-    dropEffect: "node" | "copy" | "link" | "move";
+    dropEffect: "none" | "copy" | "link" | "move";
     /**
      * Returns the kinds of operations that are to be allowed.
      * 

--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -4167,7 +4167,7 @@ interface DataTransfer {
      * 
      * The possible values are "none", "copy", "link", and "move".
      */
-    dropEffect: string;
+    dropEffect: "node" | "copy" | "link" | "move";
     /**
      * Returns the kinds of operations that are to be allowed.
      * 
@@ -4175,7 +4175,7 @@ interface DataTransfer {
      * 
      * The possible values are "none", "copy", "copyLink", "copyMove", "link", "linkMove", "move", "all", and "uninitialized",
      */
-    effectAllowed: string;
+    effectAllowed: "none" | "copy" | "copyLink" | "copyMove" | "link" | "linkMove" | "move" | "all" | "uninitialized";
     /**
      * Returns a FileList of the files being dragged, if any.
      */

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1183,7 +1183,7 @@
                     "property": {
                         "dropEffect": {
                             "name": "dropEffect",
-                            "override-type": "\"node\" | \"copy\" | \"link\" | \"move\""
+                            "override-type": "\"none\" | \"copy\" | \"link\" | \"move\""
                         },
                         "effectAllowed": {
                             "name": "effectAllowed",

--- a/inputfiles/overridingTypes.json
+++ b/inputfiles/overridingTypes.json
@@ -1177,6 +1177,21 @@
                     }
                 }
             },
+            "DataTransfer": {
+                "name": "DataTransfer",
+                "properties": {
+                    "property": {
+                        "dropEffect": {
+                            "name": "dropEffect",
+                            "override-type": "\"node\" | \"copy\" | \"link\" | \"move\""
+                        },
+                        "effectAllowed": {
+                            "name": "effectAllowed",
+                            "override-type": "\"none\" | \"copy\" | \"copyLink\" | \"copyMove\" | \"link\" | \"linkMove\" | \"move\" | \"all\" | \"uninitialized\""
+                        }
+                    }
+                }
+            },
             "DataTransferItemList": {
                 "name": "DataTransferItemList",
                 "methods": {


### PR DESCRIPTION
Now types of dropEffect and effectAllowed are string but comments restrict their values like below.
> The possible values are "none", "copy", "link", and "move".
> The possible values are "none", "copy", "copyLink", "copyMove", "link", "linkMove", "move", "all", and "uninitialized",

So I updated their types according to the comments.

