### PR TITLE
Add keyCode attribute to KeyboardEventInit

### DIFF
--- a/baselines/dom.generated.d.ts
+++ b/baselines/dom.generated.d.ts
@@ -649,6 +649,8 @@ interface KeyboardEventInit extends EventModifierInit {
     code?: string;
     isComposing?: boolean;
     key?: string;
+    /** @deprecated */
+    keyCode?: number;
     location?: number;
     repeat?: boolean;
 }

--- a/inputfiles/addedTypes.json
+++ b/inputfiles/addedTypes.json
@@ -2381,6 +2381,17 @@
                         }
                     }
                 }
+            },
+            "KeyboardEventInit": {
+                "members": {
+                    "member": {
+                        "keyCode": {
+                            "name": "keyCode",
+                            "deprecated": 1,
+                            "type": "unsigned long"
+                        }
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
It's needed to fix cross browsing issue(support IE)

Fixes https://github.com/microsoft/TypeScript/issues/15228